### PR TITLE
feat(skeleton): derived accessors (E3.1, #21)

### DIFF
--- a/Sources/SleapIO/Model/Skeleton.swift
+++ b/Sources/SleapIO/Model/Skeleton.swift
@@ -191,6 +191,51 @@ public final class Skeleton: Hashable, @unchecked Sendable {
         _nodeToIndex[ObjectIdentifier(node)]
     }
 
+    /// Whether a node with the given name exists. Mirrors Python `name in skeleton`.
+    public func contains(nodeNamed name: String) -> Bool {
+        _nameToNode[name] != nil
+    }
+
+    // MARK: - Derived accessors
+    //
+    // These mirror the read-only views Python `Skeleton` exposes and are used
+    // throughout rendering, matching, and tensor export. Edges/symmetries whose
+    // endpoints are not part of this skeleton are skipped rather than crashing.
+
+    /// Node names in order. Mirrors `Skeleton.node_names`.
+    public var nodeNames: [String] {
+        nodes.map(\.name)
+    }
+
+    /// Edges as `(sourceIndex, destinationIndex)` pairs. Mirrors `Skeleton.edge_inds`.
+    public var edgeInds: [(Int, Int)] {
+        edges.compactMap { edge in
+            guard let s = index(of: edge.source),
+                  let d = index(of: edge.destination) else { return nil }
+            return (s, d)
+        }
+    }
+
+    /// Edges as `(sourceName, destinationName)` pairs. Mirrors `Skeleton.edge_names`.
+    public var edgeNames: [(String, String)] {
+        edges.map { ($0.source.name, $0.destination.name) }
+    }
+
+    /// Symmetries as sorted `(indexA, indexB)` pairs. Mirrors `Skeleton.symmetry_inds`.
+    public var symmetryInds: [(Int, Int)] {
+        symmetries.compactMap { sym in
+            guard let a = index(of: sym.nodeA),
+                  let b = index(of: sym.nodeB) else { return nil }
+            return a <= b ? (a, b) : (b, a)
+        }
+    }
+
+    /// Symmetries as `(nameA, nameB)` pairs, ordered to match ``symmetryInds``.
+    /// Mirrors `Skeleton.symmetry_names`.
+    public var symmetryNames: [(String, String)] {
+        symmetryInds.map { (nodes[$0.0].name, nodes[$0.1].name) }
+    }
+
     // MARK: - Identity equality
 
     public static func == (lhs: Skeleton, rhs: Skeleton) -> Bool {

--- a/Tests/SleapIOTests/SkeletonAccessorsTests.swift
+++ b/Tests/SleapIOTests/SkeletonAccessorsTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import SleapIO
+
+/// E3.1: Skeleton derived accessors (node_names / edge_inds / edge_names /
+/// symmetry_inds / symmetry_names / contains), mirroring Python `Skeleton`.
+final class SkeletonAccessorsTests: XCTestCase {
+
+    /// A small skeleton: A, B_left, B_right, C with a left/right symmetry.
+    private func makeSkeleton() -> (Skeleton, [Node]) {
+        let nodes = ["A", "B_left", "B_right", "C"].map { Node(name: $0) }
+        let skel = Skeleton(name: "test", nodes: nodes)
+        skel.addEdge(from: nodes[0], to: nodes[1]) // A -> B_left
+        skel.addEdge(from: nodes[0], to: nodes[2]) // A -> B_right
+        skel.addEdge(from: nodes[1], to: nodes[3]) // B_left -> C
+        skel.addSymmetry(nodes[1], nodes[2])       // B_left <-> B_right
+        return (skel, nodes)
+    }
+
+    func testNodeNames() {
+        let (skel, _) = makeSkeleton()
+        XCTAssertEqual(skel.nodeNames, ["A", "B_left", "B_right", "C"])
+    }
+
+    func testEdgeInds() {
+        let (skel, _) = makeSkeleton()
+        XCTAssertEqual(skel.edgeInds.map { [$0.0, $0.1] }, [[0, 1], [0, 2], [1, 3]])
+    }
+
+    func testEdgeNames() {
+        let (skel, _) = makeSkeleton()
+        XCTAssertEqual(
+            skel.edgeNames.map { [$0.0, $0.1] },
+            [["A", "B_left"], ["A", "B_right"], ["B_left", "C"]]
+        )
+    }
+
+    func testSymmetryInds() {
+        let (skel, _) = makeSkeleton()
+        XCTAssertEqual(skel.symmetryInds.map { [$0.0, $0.1] }, [[1, 2]])
+    }
+
+    func testSymmetryNamesFollowSortedInds() {
+        let (skel, _) = makeSkeleton()
+        XCTAssertEqual(skel.symmetryNames.map { [$0.0, $0.1] }, [["B_left", "B_right"]])
+    }
+
+    func testSymmetryIndsAreSortedRegardlessOfInsertionOrder() {
+        let (skel, nodes) = makeSkeleton()
+        // Insert a reversed-order symmetry C(3) <-> A(0); should normalize to (0, 3).
+        skel.addSymmetry(nodes[3], nodes[0])
+        XCTAssertTrue(skel.symmetryInds.contains { [$0.0, $0.1] == [0, 3] })
+        XCTAssertFalse(skel.symmetryInds.contains { $0.0 > $0.1 })
+    }
+
+    func testContainsNodeNamed() {
+        let (skel, _) = makeSkeleton()
+        XCTAssertTrue(skel.contains(nodeNamed: "A"))
+        XCTAssertFalse(skel.contains(nodeNamed: "Z"))
+    }
+
+    func testContainsNodeByIdentity() {
+        let (skel, nodes) = makeSkeleton()
+        XCTAssertTrue(skel.contains(nodes[0]))
+        XCTAssertFalse(skel.contains(Node(name: "A"))) // distinct identity
+    }
+
+    func testEmptySkeletonAccessors() {
+        let skel = Skeleton(name: "empty")
+        XCTAssertEqual(skel.nodeNames, [])
+        XCTAssertEqual(skel.edgeInds.count, 0)
+        XCTAssertEqual(skel.symmetryInds.count, 0)
+    }
+}


### PR DESCRIPTION
Implements **E3.1** (#21) under epic **E3** (#20).

Adds the read-only derived views Python `Skeleton` exposes, used by rendering,
matching, and tensor export:

- `nodeNames`, `edgeInds`, `edgeNames`, `symmetryInds`, `symmetryNames`
- `contains(nodeNamed:)`

`symmetryInds` normalizes each pair to sorted order (matches Python
`tuple(sorted(...))`). Malformed edges/symmetries are skipped, not crashed.

**Tests:** `SkeletonAccessorsTests` (9 cases) green. Additive only — no behavior change.

Part of the GUI-readiness parity work — see `MEGA_PLAN.md` §E3 / `GAP_ANALYSIS.md`.

Closes #21.