### PR TITLE
feat(model): Instance/Frame numpy + geometry accessors (E2.1/E2.2, #14 #15)

### DIFF
--- a/Sources/SleapIO/Model/ModelNumpyAccessors.swift
+++ b/Sources/SleapIO/Model/ModelNumpyAccessors.swift
@@ -1,0 +1,103 @@
+import Foundation
+import simd
+
+// E2.1 / E2.2: numpy-style array export and derived geometry on
+// Instance / PredictedInstance / LabeledFrame, mirroring Python `sleap_io`.
+// All accessors are additive and return copies.
+
+extension Instance {
+
+    /// Points as an `(nNodes, 2)` array of `[x, y]` rows.
+    ///
+    /// - Parameter invisibleAsNaN: When `true` (default), points that are not visible
+    ///   are emitted as `[NaN, NaN]`; when `false`, the stored coordinates are returned
+    ///   regardless of visibility.
+    ///
+    /// Mirrors `Instance.numpy(invisible_as_nan=)`.
+    public func numpy(invisibleAsNaN: Bool = true) -> [[Float]] {
+        var rows = [[Float]]()
+        rows.reserveCapacity(points.count)
+        for i in 0..<points.count {
+            if invisibleAsNaN && !points.visibility[i] {
+                rows.append([.nan, .nan])
+            } else {
+                rows.append([points.coordinates[i * 2], points.coordinates[i * 2 + 1]])
+            }
+        }
+        return rows
+    }
+
+    /// Number of visible points. Mirrors `Instance.n_visible`.
+    public var nVisible: Int {
+        var n = 0
+        for v in points.visibility where v { n += 1 }
+        return n
+    }
+
+    /// Whether no points are visible. Mirrors `Instance.is_empty`.
+    public var isEmpty: Bool {
+        !points.visibility.contains(true)
+    }
+
+    /// Mean `(x, y)` of visible, finite points, or `nil` if there are none.
+    /// Mirrors `Instance.centroid_xy`.
+    public var centroidXY: SIMD2<Float>? {
+        var sumX: Float = 0, sumY: Float = 0
+        var n = 0
+        for i in 0..<points.count where points.visibility[i] {
+            let x = points.coordinates[i * 2], y = points.coordinates[i * 2 + 1]
+            guard x.isFinite, y.isFinite else { continue }
+            sumX += x; sumY += y; n += 1
+        }
+        guard n > 0 else { return nil }
+        return SIMD2(sumX / Float(n), sumY / Float(n))
+    }
+
+    /// Bounding box of visible points as `[[minX, minY], [maxX, maxY]]`, or `nil`
+    /// if there are no visible points. Mirrors `Instance.bounding_box`.
+    ///
+    /// (The existing ``boundingBox`` property returns the same extent as a `CGRect`.)
+    public func boundingBoxArray() -> [[Float]]? {
+        var minX = Float.greatestFiniteMagnitude, minY = Float.greatestFiniteMagnitude
+        var maxX = -Float.greatestFiniteMagnitude, maxY = -Float.greatestFiniteMagnitude
+        var any = false
+        for i in 0..<points.count where points.visibility[i] {
+            let x = points.coordinates[i * 2], y = points.coordinates[i * 2 + 1]
+            guard x.isFinite, y.isFinite else { continue }
+            any = true
+            minX = min(minX, x); minY = min(minY, y)
+            maxX = max(maxX, x); maxY = max(maxY, y)
+        }
+        guard any else { return nil }
+        return [[minX, minY], [maxX, maxY]]
+    }
+}
+
+extension PredictedInstance {
+
+    /// Points as `(nNodes, 2)` rows, or `(nNodes, 3)` with a per-point score column
+    /// when `scores` is `true`. The score column is never replaced with `NaN`.
+    ///
+    /// Mirrors `PredictedInstance.numpy(invisible_as_nan=, scores=)`.
+    public func numpy(invisibleAsNaN: Bool = true, scores: Bool) -> [[Float]] {
+        let xy = numpy(invisibleAsNaN: invisibleAsNaN) // Instance.numpy(invisibleAsNaN:)
+        guard scores else { return xy }
+        var rows = [[Float]]()
+        rows.reserveCapacity(xy.count)
+        for i in 0..<xy.count {
+            rows.append([xy[i][0], xy[i][1], predictedPoints.scores[i]])
+        }
+        return rows
+    }
+}
+
+extension LabeledFrame {
+
+    /// All instances as an `(nInstances, nNodes, 2)` array, with invisible points as
+    /// `NaN`. `nNodes` is taken from the first instance. Mirrors `LabeledFrame.numpy`.
+    ///
+    /// Note: instance order is whatever ``instances`` holds.
+    public func numpy() -> [[[Float]]] {
+        instances.map { $0.numpy(invisibleAsNaN: true) }
+    }
+}

--- a/Tests/SleapIOTests/InstanceAccessorsTests.swift
+++ b/Tests/SleapIOTests/InstanceAccessorsTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+import simd
+@testable import SleapIO
+
+/// E2.1 / E2.2: Instance/Frame numpy export + geometry accessors.
+final class InstanceAccessorsTests: XCTestCase {
+
+    private func skel3() -> (Skeleton, [Node]) {
+        let nodes = ["a", "b", "c"].map { Node(name: $0) }
+        return (Skeleton(name: "s", nodes: nodes), nodes)
+    }
+
+    /// Build a user instance: a=(0,0) visible, b=(10,20) visible, c invisible.
+    private func twoVisibleInstance() -> Instance {
+        let (skel, nodes) = skel3()
+        let inst = Instance(skeleton: skel)
+        inst[nodes[0]] = Point(x: 0, y: 0, visible: true, complete: true)
+        inst[nodes[1]] = Point(x: 10, y: 20, visible: true, complete: true)
+        inst[nodes[2]] = Point(x: 99, y: 99, visible: false, complete: false)
+        return inst
+    }
+
+    func testNumpyInvisibleAsNaN() {
+        let inst = twoVisibleInstance()
+        let arr = inst.numpy() // invisibleAsNaN: true by default
+        XCTAssertEqual(arr.count, 3)
+        XCTAssertEqual(arr[0], [0, 0])
+        XCTAssertEqual(arr[1], [10, 20])
+        XCTAssertTrue(arr[2][0].isNaN && arr[2][1].isNaN, "invisible point should be NaN")
+    }
+
+    func testNumpyKeepsStoredCoordsWhenNotNaN() {
+        let inst = twoVisibleInstance()
+        let arr = inst.numpy(invisibleAsNaN: false)
+        XCTAssertEqual(arr[2], [99, 99], "invisibleAsNaN:false returns stored coords")
+    }
+
+    func testNVisible() {
+        XCTAssertEqual(twoVisibleInstance().nVisible, 2)
+    }
+
+    func testIsEmpty() {
+        XCTAssertFalse(twoVisibleInstance().isEmpty)
+        let (skel, _) = skel3()
+        XCTAssertTrue(Instance(skeleton: skel).isEmpty, "all-invisible instance is empty")
+    }
+
+    func testCentroidXY() {
+        let c = twoVisibleInstance().centroidXY
+        XCTAssertNotNil(c)
+        XCTAssertEqual(c!.x, 5, accuracy: 1e-6)  // (0 + 10) / 2
+        XCTAssertEqual(c!.y, 10, accuracy: 1e-6) // (0 + 20) / 2
+    }
+
+    func testCentroidXYNilWhenEmpty() {
+        let (skel, _) = skel3()
+        XCTAssertNil(Instance(skeleton: skel).centroidXY)
+    }
+
+    func testBoundingBoxArray() {
+        let bb = twoVisibleInstance().boundingBoxArray()
+        XCTAssertEqual(bb?[0], [0, 0])    // min
+        XCTAssertEqual(bb?[1], [10, 20])  // max
+    }
+
+    func testBoundingBoxArrayNilWhenEmpty() {
+        let (skel, _) = skel3()
+        XCTAssertNil(Instance(skeleton: skel).boundingBoxArray())
+    }
+
+    func testPredictedInstanceNumpyWithScores() {
+        let (skel, nodes) = skel3()
+        var pts = PredictedPointsArray(count: 3)
+        pts.skeleton = skel
+        pts[nodes[0]] = PredictedPoint(point: Point(x: 1, y: 2, visible: true, complete: true), score: 0.9)
+        pts[nodes[1]] = PredictedPoint(point: Point(x: 3, y: 4, visible: true, complete: true), score: 0.8)
+        pts[nodes[2]] = PredictedPoint(point: Point(x: 0, y: 0, visible: false, complete: false), score: 0.1)
+        let pred = PredictedInstance(skeleton: skel, points: pts, score: 0.95)
+
+        let withScores = pred.numpy(scores: true)
+        XCTAssertEqual(withScores[0], [1, 2, 0.9])
+        XCTAssertEqual(withScores[1], [3, 4, 0.8])
+        // invisible -> xy NaN, but score column preserved
+        XCTAssertTrue(withScores[2][0].isNaN && withScores[2][1].isNaN)
+        XCTAssertEqual(withScores[2][2], 0.1, accuracy: 1e-6)
+
+        let noScores = pred.numpy(scores: false)
+        XCTAssertEqual(noScores[0].count, 2)
+    }
+
+    func testLabeledFrameNumpyShape() {
+        let inst1 = twoVisibleInstance()
+        let inst2 = twoVisibleInstance()
+        let frame = LabeledFrame(video: Video(filename: "v.mp4"), frameIndex: 0,
+                                 instances: [inst1, inst2])
+        let arr = frame.numpy()
+        XCTAssertEqual(arr.count, 2)         // n_instances
+        XCTAssertEqual(arr[0].count, 3)      // n_nodes
+        XCTAssertEqual(arr[0][0].count, 2)   // xy
+        XCTAssertEqual(arr[1][1], [10, 20])
+    }
+}


### PR DESCRIPTION
Implements **E2.1** (#14) and **E2.2** (#15) under epic **E2** (#13). These two
sub-issues are tightly coupled (both additive Instance accessors) so they share
one PR.

- `Instance.numpy(invisibleAsNaN:)`, `nVisible`, `isEmpty`, `centroidXY`, `boundingBoxArray()`
- `PredictedInstance.numpy(invisibleAsNaN:scores:)` (score column preserved even for invisible points)
- `LabeledFrame.numpy()` → `(nInstances, nNodes, 2)`

Semantics verified against Python `instance.py` / `labeled_frame.py` (invisible → NaN via the `visible` mask).

**Tests:** `InstanceAccessorsTests` (10 cases) green. Additive only.

See `MEGA_PLAN.md` §E2 / `GAP_ANALYSIS.md` §4.

Closes #14. Closes #15.