### PR TITLE
feat(labels): count accessors (E1.5, #11)

### DIFF
--- a/Sources/SleapIO/Model/LabelsCounts.swift
+++ b/Sources/SleapIO/Model/LabelsCounts.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+// E1.5: Count accessors used by sidebars / QC, mirroring Python `Labels`.
+// Instance counts are O(1) on the lazy store; the per-track count and
+// `userLabeledFrames` iterate frames (materializing lazy frames).
+
+extension Labels {
+
+    /// Total number of user-labeled (non-predicted) instances across all frames.
+    /// O(1) when lazy (derived from column-store row counts).
+    /// Mirrors `Labels.n_user_instances`.
+    public var nUserInstances: Int {
+        instanceCount - predictedInstanceCount
+    }
+
+    /// Total number of predicted instances across all frames.
+    /// O(1) when lazy. Mirrors `Labels.n_pred_instances`.
+    public var nPredInstances: Int {
+        predictedInstanceCount
+    }
+
+    /// Number of labeled frames for each video.
+    ///
+    /// Uses ``frameMetadata()`` so it does not materialize frames when lazy.
+    /// Mirrors `Labels.n_frames_per_video`.
+    public func nFramesPerVideo() -> [Video: Int] {
+        var perIndex = [Int: Int]()
+        for m in frameMetadata() {
+            perIndex[m.videoIndex, default: 0] += 1
+        }
+        var counts = [Video: Int]()
+        for (i, v) in videos.enumerated() {
+            counts[v] = perIndex[i] ?? 0
+        }
+        return counts
+    }
+
+    /// Number of instances for each track. Untracked instances are not counted.
+    ///
+    /// Iterates instances, so this materializes lazy frames. Mirrors
+    /// `Labels.n_instances_per_track`.
+    public func nInstancesPerTrack() -> [Track: Int] {
+        var counts = [Track: Int]()
+        for t in tracks { counts[t] = 0 }
+        for i in 0..<frameCount {
+            for inst in self[i].instances {
+                if let t = inst.track {
+                    counts[t, default: 0] += 1
+                }
+            }
+        }
+        return counts
+    }
+
+    /// Frames containing at least one user-labeled instance.
+    ///
+    /// Iterates frames, so this materializes lazy frames. Mirrors
+    /// `Labels.user_labeled_frames`.
+    public var userLabeledFrames: [LabeledFrame] {
+        (0..<frameCount).map { self[$0] }.filter { $0.hasUserInstances }
+    }
+}

--- a/Tests/SleapIOTests/LabelsCountsTests.swift
+++ b/Tests/SleapIOTests/LabelsCountsTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import SleapIO
+
+/// E1.5: Labels count accessors.
+final class LabelsCountsTests: XCTestCase {
+
+    private func makeLabels() throws -> (Labels, Skeleton, Video, Video, Track, Track) {
+        let skel = Skeleton(name: "s", nodes: [Node(name: "a"), Node(name: "b")])
+        let v1 = Video(filename: "v1.mp4")
+        let v2 = Video(filename: "v2.mp4")
+        let t1 = Track(name: "t1")
+        let t2 = Track(name: "t2")
+        let labels = Labels()
+
+        // v1 frame 0: 1 user (t1) + 1 predicted (t2)
+        let f0 = LabeledFrame(video: v1, frameIndex: 0)
+        f0.instances.append(Instance(skeleton: skel, track: t1))
+        f0.instances.append(PredictedInstance(skeleton: skel,
+                                              points: PredictedPointsArray(count: 2),
+                                              score: 0.5, track: t2))
+        // v1 frame 1: 1 user (t1), no user-vs-pred mix
+        let f1 = LabeledFrame(video: v1, frameIndex: 1)
+        f1.instances.append(Instance(skeleton: skel, track: t1))
+        // v2 frame 0: empty (no instances)
+        let f2 = LabeledFrame(video: v2, frameIndex: 0)
+
+        try labels.addFrame(f0)
+        try labels.addFrame(f1)
+        try labels.addFrame(f2)
+        return (labels, skel, v1, v2, t1, t2)
+    }
+
+    func testUserAndPredictedCounts() throws {
+        let (labels, _, _, _, _, _) = try makeLabels()
+        XCTAssertEqual(labels.nUserInstances, 2) // f0 user + f1 user
+        XCTAssertEqual(labels.nPredInstances, 1) // f0 predicted
+    }
+
+    func testFramesPerVideo() throws {
+        let (labels, _, v1, v2, _, _) = try makeLabels()
+        let counts = labels.nFramesPerVideo()
+        XCTAssertEqual(counts[v1], 2)
+        XCTAssertEqual(counts[v2], 1)
+    }
+
+    func testInstancesPerTrack() throws {
+        let (labels, _, _, _, t1, t2) = try makeLabels()
+        let counts = labels.nInstancesPerTrack()
+        XCTAssertEqual(counts[t1], 2) // f0 + f1
+        XCTAssertEqual(counts[t2], 1) // f0 predicted
+    }
+
+    func testUserLabeledFrames() throws {
+        let (labels, _, v1, _, _, _) = try makeLabels()
+        let frames = labels.userLabeledFrames
+        XCTAssertEqual(frames.count, 2) // f0 and f1 have user instances; f2 empty
+        XCTAssertTrue(frames.allSatisfy { $0.video === v1 })
+    }
+}


### PR DESCRIPTION
Implements **E1.5** (#11) under epic **E1** (#6).

- `nUserInstances`, `nPredInstances` — O(1) on the lazy column store
- `nFramesPerVideo()` — uses `frameMetadata()`, no frame materialization
- `nInstancesPerTrack()`, `userLabeledFrames` — iterate (materialize when lazy; documented)

Semantics match Python `labels.py` (`n_user_instances`/`n_pred_instances`/`n_frames_per_video`/`n_instances_per_track`/`user_labeled_frames`).

**Tests:** `LabelsCountsTests` (4 cases) green. Additive only.

Closes #11.