### PR TITLE
docs(model): CoordinateConventions reference + helpers (E4.1, #27)

### DIFF
--- a/Sources/SleapIO/Model/CoordinateConventions.swift
+++ b/Sources/SleapIO/Model/CoordinateConventions.swift
@@ -1,0 +1,66 @@
+import Foundation
+import simd
+
+/// Canonical coordinate and visibility conventions for SLEAP pose data.
+///
+/// These rules are an implicit, cross-cutting invariant in the data format. A
+/// rendering layer and a SwiftUI `Canvas` overlay **must** agree on them or every
+/// annotation will be mirrored / offset. This type documents them in one place and
+/// provides the small conversions needed to honor them.
+///
+/// ## Image coordinate space (the storage convention)
+///
+/// - Coordinates are stored in **pixel units** in the video's native image space.
+/// - The origin `(0, 0)` is the **top-left** corner; **x** increases to the right,
+///   **y** increases **downward** (image / "y-down" convention). This matches how
+///   SwiftUI's `Canvas`, AppKit `CGContext` flipped contexts, and most image
+///   pipelines address pixels.
+/// - A coordinate addresses the **center** of a pixel. SLP format versions < 1.1
+///   stored corner-indexed coordinates; the reader applies a
+///   ``pixelCenterCorrection`` of `-0.5` on read so all in-memory coordinates use
+///   the pixel-center convention. See `SLPReader`.
+///
+/// ## Y-axis when drawing
+///
+/// Some drawing back ends (e.g. a non-flipped Core Graphics / Quartz context, or a
+/// 3D/visionOS scene) use a **y-up** coordinate system with the origin at the
+/// bottom-left. When targeting such a context, flip y with ``flipY(_:imageHeight:)``
+/// (it is its own inverse). SwiftUI `Canvas` is already y-down, so no flip is needed
+/// there.
+///
+/// ## Invisible points
+///
+/// Visibility is carried by the **`visible` flag**, not by the coordinate value.
+/// The canonical "missing" sentinel for array/tensor export is **`NaN`**:
+/// ``Instance/numpy(invisibleAsNaN:)`` emits `[NaN, NaN]` for any point whose
+/// `visible` flag is `false`, regardless of the stored coordinate. Consumers that
+/// reduce over points (centroid, bounding box, training tensors) should treat
+/// `visible == false` (equivalently, a `NaN` row) as absent.
+public enum CoordinateConventions {
+
+    /// The per-axis correction applied on read for SLP format versions < 1.1 to
+    /// convert corner-indexed coordinates to the pixel-center convention.
+    ///
+    /// Stored value is the amount **subtracted** from each legacy coordinate.
+    public static let pixelCenterCorrection: Float = 0.5
+
+    /// Convert a y coordinate between the image (y-down, top-left origin) convention
+    /// and a y-up (bottom-left origin) convention for an image of the given height.
+    ///
+    /// This is an involution: applying it twice returns the original value.
+    ///
+    /// - Parameters:
+    ///   - y: The y coordinate to convert.
+    ///   - imageHeight: The height of the image in pixels.
+    @inline(__always)
+    public static func flipY(_ y: Float, imageHeight: Float) -> Float {
+        imageHeight - y
+    }
+
+    /// Convert a point's y between image (y-down) and y-up conventions for an image
+    /// of the given height. Its own inverse.
+    @inline(__always)
+    public static func flipY(_ point: SIMD2<Float>, imageHeight: Float) -> SIMD2<Float> {
+        SIMD2(point.x, imageHeight - point.y)
+    }
+}

--- a/Tests/SleapIOTests/CoordinateConventionsTests.swift
+++ b/Tests/SleapIOTests/CoordinateConventionsTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+import simd
+@testable import SleapIO
+
+/// E4.1: Coordinate-convention helpers.
+final class CoordinateConventionsTests: XCTestCase {
+
+    func testPixelCenterCorrectionValue() {
+        XCTAssertEqual(CoordinateConventions.pixelCenterCorrection, 0.5)
+    }
+
+    func testFlipYScalar() {
+        XCTAssertEqual(CoordinateConventions.flipY(10, imageHeight: 100), 90)
+        XCTAssertEqual(CoordinateConventions.flipY(0, imageHeight: 100), 100)
+    }
+
+    func testFlipYIsItsOwnInverse() {
+        let h: Float = 480
+        for y: Float in [0, 1.5, 239, 479, 480] {
+            let back = CoordinateConventions.flipY(CoordinateConventions.flipY(y, imageHeight: h), imageHeight: h)
+            XCTAssertEqual(back, y, accuracy: 1e-4)
+        }
+    }
+
+    func testFlipYPoint() {
+        let p = CoordinateConventions.flipY(SIMD2<Float>(7, 30), imageHeight: 100)
+        XCTAssertEqual(p.x, 7)   // x unchanged
+        XCTAssertEqual(p.y, 70)  // y flipped
+    }
+}


### PR DESCRIPTION
Implements **E4.1** (#27) under epic **E4** (#26).

Documents the implicit coordinate/visibility invariant in one place and adds the
small conversions needed to honor it:
- `CoordinateConventions` namespace (pixel-center, pre-1.1 0.5 shift, y-down image
  space vs y-up draw contexts, NaN-as-invisible)
- `pixelCenterCorrection` constant; `flipY(_:imageHeight:)` (scalar + point, involution)

Prevents the "every annotation is mirrored" class of GUI overlay/hit-testing bugs.

**Tests:** `CoordinateConventionsTests` (4 cases) green.

Closes #27.