### PR TITLE
feat(video): Video metadata accessors (E11.1, #60)

### DIFF
--- a/Sources/SleapIO/Model/VideoAccessors.swift
+++ b/Sources/SleapIO/Model/VideoAccessors.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+// E11.1: Video metadata accessors mirroring Python `Video`.
+//
+// These operate on the in-memory model only. Opening/closing a decode backend
+// lives in the SleapVideo module (the SleapIO `Video` type has no backend), so
+// `open`/`close`/`isOpen` are intentionally not part of this layer.
+
+extension Video {
+
+    /// Video shape as `(frames, height, width, channels)`, or `nil` if either the
+    /// frame count or frame size is unknown. Mirrors `Video.shape`.
+    public var shape: (frames: Int, height: Int, width: Int, channels: Int)? {
+        guard let n = frameCount, let s = frameSize else { return nil }
+        return (n, s.height, s.width, s.channels)
+    }
+
+    /// Whether the video is grayscale (single channel), or `nil` if the frame size
+    /// is unknown. Setting it updates the channel count of ``frameSize`` (1 for
+    /// grayscale, 3 otherwise); a no-op while the frame size is unknown.
+    /// Mirrors `Video.grayscale`.
+    public var grayscale: Bool? {
+        get { frameSize.map { $0.channels == 1 } }
+        set {
+            guard let want = newValue, let s = frameSize else { return }
+            frameSize = (height: s.height, width: s.width, channels: want ? 1 : 3)
+        }
+    }
+
+    /// Whether the backing file exists on disk at ``filename``. Mirrors `Video.exists`.
+    public var exists: Bool {
+        var path = filename
+        if path.hasPrefix("file://"), let url = URL(string: path) {
+            path = url.path
+        }
+        return FileManager.default.fileExists(atPath: path)
+    }
+
+    /// Frames per second, read from `backendMetadata["fps"]` if present.
+    public var fps: Double? {
+        switch backendMetadata["fps"] {
+        case let d as Double: return d
+        case let i as Int: return Double(i)
+        case let f as Float: return Double(f)
+        case let s as String: return Double(s)
+        default: return nil
+        }
+    }
+
+    /// Convert a frame index to a time in seconds using ``fps``, or `nil` if unknown.
+    public func frameToSeconds(_ frameIndex: Int) -> Double? {
+        guard let fps = fps, fps > 0 else { return nil }
+        return Double(frameIndex) / fps
+    }
+
+    /// Convert a time in seconds to the nearest frame index using ``fps``, or `nil`.
+    public func secondsToFrame(_ seconds: Double) -> Int? {
+        guard let fps = fps, fps > 0 else { return nil }
+        return Int((seconds * fps).rounded())
+    }
+
+    /// Create a `Video` inferring the backend type from the file extension.
+    /// Mirrors `Video.from_filename`.
+    public static func from(filename: String) -> Video {
+        Video(filename: filename, backendType: inferBackendType(filename))
+    }
+
+    /// Infer a backend-type identifier ("media" / "hdf5" / "imageSequence") from a
+    /// file extension.
+    static func inferBackendType(_ filename: String) -> String {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        switch ext {
+        case "mp4", "mov", "avi", "m4v", "mkv", "webm", "mpg", "mpeg":
+            return "media"
+        case "h5", "hdf5", "slp", "pkg":
+            return "hdf5"
+        case "png", "jpg", "jpeg", "tif", "tiff", "bmp", "gif":
+            return "imageSequence"
+        default:
+            return "media"
+        }
+    }
+}

--- a/Tests/SleapIOTests/VideoAccessorsTests.swift
+++ b/Tests/SleapIOTests/VideoAccessorsTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import SleapIO
+
+/// E11.1: Video metadata accessors.
+final class VideoAccessorsTests: XCTestCase {
+
+    func testShape() {
+        let v = Video(filename: "v.mp4")
+        XCTAssertNil(v.shape)
+        v.frameCount = 100
+        v.frameSize = (height: 480, width: 640, channels: 3)
+        let s = v.shape
+        XCTAssertEqual(s?.frames, 100)
+        XCTAssertEqual(s?.height, 480)
+        XCTAssertEqual(s?.width, 640)
+        XCTAssertEqual(s?.channels, 3)
+    }
+
+    func testGrayscaleGetSet() {
+        let v = Video(filename: "v.mp4")
+        XCTAssertNil(v.grayscale) // unknown frame size
+        v.frameSize = (height: 10, width: 10, channels: 3)
+        XCTAssertEqual(v.grayscale, false)
+        v.grayscale = true
+        XCTAssertEqual(v.frameSize?.channels, 1)
+        XCTAssertEqual(v.grayscale, true)
+        v.grayscale = false
+        XCTAssertEqual(v.frameSize?.channels, 3)
+    }
+
+    func testExists() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sleapio_exists_\(UUID().uuidString).txt")
+        try "x".write(to: tmp, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let present = Video(filename: tmp.path)
+        XCTAssertTrue(present.exists)
+
+        let absent = Video(filename: "/definitely/not/here_\(UUID().uuidString).mp4")
+        XCTAssertFalse(absent.exists)
+    }
+
+    func testFpsAndTimeMapping() {
+        let v = Video(filename: "v.mp4", backendMetadata: ["fps": 30.0])
+        XCTAssertEqual(v.fps, 30.0)
+        XCTAssertEqual(v.frameToSeconds(60), 2.0)
+        XCTAssertEqual(v.secondsToFrame(2.0), 60)
+    }
+
+    func testFpsMissing() {
+        let v = Video(filename: "v.mp4")
+        XCTAssertNil(v.fps)
+        XCTAssertNil(v.frameToSeconds(10))
+        XCTAssertNil(v.secondsToFrame(1.0))
+    }
+
+    func testFromFilenameInfersBackend() {
+        XCTAssertEqual(Video.from(filename: "/a/b/clip.mp4").backendType, "media")
+        XCTAssertEqual(Video.from(filename: "/a/b/proj.slp").backendType, "hdf5")
+        XCTAssertEqual(Video.from(filename: "/a/b/frame.png").backendType, "imageSequence")
+        XCTAssertEqual(Video.from(filename: "/a/b/unknown.xyz").backendType, "media")
+    }
+}


### PR DESCRIPTION
Implements **E11.1** (#60) under epic **E11** (#59).

Model-level `Video` accessors mirroring Python `Video`:
- `shape`, `grayscale` (get/set), `exists`, `fps`, `frameToSeconds`/`secondsToFrame`
- `Video.from(filename:)` inferring `backendType` by extension

`open`/`close`/`isOpen` are intentionally out of scope here — the SleapIO `Video`
has no decode backend; those belong to SleapVideo (follow-up under E11/E12).

**Tests:** `VideoAccessorsTests` (6 cases) green. Additive only.

Closes #60.