### PR TITLE
perf(labels): O(1) cached frame lookup (E1.1, #7)

### DIFF
--- a/Sources/SleapIO/Model/Labels.swift
+++ b/Sources/SleapIO/Model/Labels.swift
@@ -103,6 +103,7 @@ public final class Labels: @unchecked Sendable {
             throw SleapIOError.mutationWhileLazy("Cannot replace videos while lazy. Call materialize() first.")
         }
         _videos = videos
+        invalidateFrameLookup()
     }
 
     /// Replace the skeletons list. Throws `mutationWhileLazy` if `isLazy`.
@@ -174,6 +175,9 @@ public final class Labels: @unchecked Sendable {
         guard isLazy else { return }
         let allFrames = frameStore.allFrames()
         frameStore = EagerFrameStore(frames: allFrames)
+        // Frame order is preserved by allFrames(), but invalidate defensively so the
+        // index is rebuilt against the eager store.
+        invalidateFrameLookup()
     }
 
     // MARK: - Query
@@ -191,14 +195,54 @@ public final class Labels: @unchecked Sendable {
     }
 
     /// The labeled frame for a specific video and frame index, if it exists.
+    ///
+    /// Backed by a cached `(videoIndex, frameIndex) -> store position` index that is
+    /// built lazily on first use (via ``frameMetadata()``, so it does not materialize
+    /// lazy frames) and invalidated on structural mutation. This makes repeated
+    /// lookups O(1) instead of the previous O(n) linear scan.
     public func frame(for video: Video, at frameIndex: Int) -> LabeledFrame? {
-        for i in 0..<frameStore.count {
-            let f = frameStore.frame(at: i)
-            if f.video === video && f.frameIndex == frameIndex {
-                return f
-            }
+        guard let videoIdx = videoIndex(of: video) else {
+            return nil
         }
-        return nil
+        guard let position = frameLookup()[FrameKey(video: videoIdx, frame: frameIndex)] else {
+            return nil
+        }
+        return frameStore.frame(at: position)
+    }
+
+    /// Index of a video in the identity table by object identity, or `nil`.
+    private func videoIndex(of video: Video) -> Int? {
+        _videos.firstIndex { $0 === video }
+    }
+
+    // MARK: - Frame lookup index
+
+    private struct FrameKey: Hashable {
+        let video: Int
+        let frame: Int
+    }
+
+    /// Cached `(videoIndex, frameIndex) -> store position` map. Invalidated by
+    /// structural mutations (add/remove/merge/materialize/replace videos).
+    private var _frameLookupCache: [FrameKey: Int]?
+
+    private func frameLookup() -> [FrameKey: Int] {
+        if let cache = _frameLookupCache { return cache }
+        let meta = frameMetadata()
+        var map = [FrameKey: Int](minimumCapacity: meta.count)
+        for (position, m) in meta.enumerated() {
+            // First occurrence wins, matching the previous linear-scan semantics.
+            let key = FrameKey(video: m.videoIndex, frame: m.frameIndex)
+            if map[key] == nil { map[key] = position }
+        }
+        _frameLookupCache = map
+        return map
+    }
+
+    /// Invalidate the frame-lookup index. Call after any structural mutation that
+    /// changes the frame list or the video ordering.
+    private func invalidateFrameLookup() {
+        _frameLookupCache = nil
     }
 
     /// All instances across all frames that belong to a given track.
@@ -268,6 +312,7 @@ public final class Labels: @unchecked Sendable {
     public func addFrame(_ frame: LabeledFrame) throws {
         try requireMaterialized("add frame")
         eagerStore.frames.append(frame)
+        invalidateFrameLookup()
         // Register new identity objects
         if !_videos.contains(where: { $0 === frame.video }) {
             _videos.append(frame.video)
@@ -286,6 +331,7 @@ public final class Labels: @unchecked Sendable {
     public func removeFrame(_ frame: LabeledFrame) throws {
         try requireMaterialized("remove frame")
         eagerStore.frames.removeAll { $0 === frame }
+        invalidateFrameLookup()
     }
 
     /// Remove all predicted instances from all frames.
@@ -339,6 +385,9 @@ public final class Labels: @unchecked Sendable {
                 existing.merge(from: otherFrame, strategy: strategy)
             } else {
                 eagerStore.frames.append(otherFrame)
+                // Keep the lookup index consistent so a later iteration that targets
+                // the same (video, frameIndex) finds this newly appended frame.
+                invalidateFrameLookup()
             }
         }
     }

--- a/Tests/SleapIOTests/LabelsFrameIndexTests.swift
+++ b/Tests/SleapIOTests/LabelsFrameIndexTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import SleapIO
+
+/// E1.1: O(1) cached frame lookup in `Labels.frame(for:at:)`.
+final class LabelsFrameIndexTests: XCTestCase {
+
+    private let skel = Skeleton(name: "s", nodes: [Node(name: "a")])
+
+    private func makeLabels() throws -> (Labels, Video, Video) {
+        let v1 = Video(filename: "v1.mp4")
+        let v2 = Video(filename: "v2.mp4")
+        let labels = Labels()
+        for idx in [0, 5, 10] { try labels.addFrame(LabeledFrame(video: v1, frameIndex: idx)) }
+        for idx in [0, 7] { try labels.addFrame(LabeledFrame(video: v2, frameIndex: idx)) }
+        return (labels, v1, v2)
+    }
+
+    /// Brute-force reference matching the previous linear-scan semantics.
+    private func linearScan(_ labels: Labels, _ video: Video, _ frameIndex: Int) -> LabeledFrame? {
+        for f in labels where f.video === video && f.frameIndex == frameIndex { return f }
+        return nil
+    }
+
+    func testMatchesLinearScan() throws {
+        let (labels, v1, v2) = try makeLabels()
+        for (v, idxs) in [(v1, [0, 5, 10, 3]), (v2, [0, 7, 1])] {
+            for idx in idxs {
+                XCTAssertTrue(labels.frame(for: v, at: idx) === linearScan(labels, v, idx),
+                              "mismatch for frame \(idx)")
+            }
+        }
+    }
+
+    func testReturnsNilForMissing() throws {
+        let (labels, v1, _) = try makeLabels()
+        XCTAssertNil(labels.frame(for: v1, at: 999))
+    }
+
+    func testCrossVideoIsolation() throws {
+        let (labels, v1, v2) = try makeLabels()
+        // v2 has frame 7; v1 does not.
+        XCTAssertNotNil(labels.frame(for: v2, at: 7))
+        XCTAssertNil(labels.frame(for: v1, at: 7))
+    }
+
+    func testInvalidatesOnAdd() throws {
+        let (labels, v1, _) = try makeLabels()
+        XCTAssertNil(labels.frame(for: v1, at: 42)) // primes the cache
+        let f = LabeledFrame(video: v1, frameIndex: 42)
+        try labels.addFrame(f)
+        XCTAssertTrue(labels.frame(for: v1, at: 42) === f, "new frame must be found after add")
+    }
+
+    func testInvalidatesOnRemove() throws {
+        let (labels, v1, _) = try makeLabels()
+        let f = labels.frame(for: v1, at: 5)!
+        try labels.removeFrame(f)
+        XCTAssertNil(labels.frame(for: v1, at: 5), "removed frame must not be found")
+        XCTAssertNotNil(labels.frame(for: v1, at: 10), "other frames still found")
+    }
+
+    func testForeignVideoObjectReturnsNil() throws {
+        let (labels, _, _) = try makeLabels()
+        let foreign = Video(filename: "v1.mp4") // same path, different identity
+        XCTAssertNil(labels.frame(for: foreign, at: 0),
+                     "foreign Video object is not resolved (identity semantics; see E1.2)")
+    }
+
+    func testRepeatedLookupsConsistent() throws {
+        let (labels, v1, _) = try makeLabels()
+        let a = labels.frame(for: v1, at: 10)
+        let b = labels.frame(for: v1, at: 10)
+        XCTAssertTrue(a === b)
+    }
+}


### PR DESCRIPTION
Implements **E1.1** (#7) under epic **E1** (#6) — the known O(n) frame-lookup issue.

`Labels.frame(for:at:)` now uses a cached `(videoIndex, frameIndex) -> store
position` index, built lazily via `frameMetadata()` (no frame materialization when
lazy) and invalidated on `addFrame`/`removeFrame`/`merge`/`materialize`/`setVideos`.

- Identity semantics preserved: foreign `Video` objects return `nil` (E1.2 will add
  resolution); first occurrence wins, matching the old linear scan.
- `merge` invalidates after each appended frame so same-key later iterations still
  find the appended frame.

**Tests:** `LabelsFrameIndexTests` (7 cases) incl. a brute-force linear-scan
equivalence check + invalidation. Full SleapIO target green (233 tests), so
`LabelsQueryTests`/`LabelsMergeTests` are unregressed.

Closes #7.