### PR TITLE
feat(core): version constant + provenance stamping (E4.2, #28)

### DIFF
--- a/Sources/SleapHDF5/SLP/LabelsIO.swift
+++ b/Sources/SleapHDF5/SLP/LabelsIO.swift
@@ -74,6 +74,7 @@ extension Labels {
 
         switch resolvedFormat {
         case .slp:
+            stampSleapIOVersion()
             try await SLPWriter.write(self, to: url.path)
         case .cocoJSON:
             try COCOCodec.write(self, to: url.path)

--- a/Sources/SleapIO/SleapIOInfo.swift
+++ b/Sources/SleapIO/SleapIOInfo.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Library version and capability introspection for sleap-io.swift.
+///
+/// Mirrors Python `sleap_io.__version__` and the supported-format surface so a GUI
+/// can display compatibility info and stamp provenance on save.
+public enum SleapIOInfo {
+
+    /// The sleap-io.swift library version.
+    public static let version = "0.3.0"
+
+    /// The SLP format versions this build can read/write.
+    ///
+    /// - Note: Extending the upper bound is tracked by epic E7 (read SLP ≥ 1.6).
+    public static let supportedSLPFormatVersions: ClosedRange<Double> = 1.0...1.5
+
+    /// The provenance key under which the library stamps its version on save.
+    public static let provenanceVersionKey = "sleap_io_swift_version"
+}
+
+extension Labels {
+
+    /// Record the sleap-io.swift version in ``provenance`` (under
+    /// ``SleapIOInfo/provenanceVersionKey``). Called automatically when saving an
+    /// `.slp`, mirroring Python writing `provenance["sleap_io_version"]`.
+    ///
+    /// - Returns: The stamped version string.
+    @discardableResult
+    public func stampSleapIOVersion() -> String {
+        let version = SleapIOInfo.version
+        provenance[SleapIOInfo.provenanceVersionKey] = version
+        return version
+    }
+}

--- a/Tests/SleapIOTests/SleapIOInfoTests.swift
+++ b/Tests/SleapIOTests/SleapIOInfoTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import SleapIO
+
+/// E4.2: Library version + provenance stamping.
+final class SleapIOInfoTests: XCTestCase {
+
+    func testVersionIsNonEmptySemver() {
+        let v = SleapIOInfo.version
+        XCTAssertFalse(v.isEmpty)
+        let parts = v.split(separator: ".")
+        XCTAssertEqual(parts.count, 3, "expected major.minor.patch")
+        XCTAssertTrue(parts.allSatisfy { Int($0) != nil }, "all components numeric")
+    }
+
+    func testSupportedSLPRange() {
+        XCTAssertTrue(SleapIOInfo.supportedSLPFormatVersions.contains(1.0))
+        XCTAssertTrue(SleapIOInfo.supportedSLPFormatVersions.contains(1.5))
+    }
+
+    func testStampSleapIOVersion() {
+        let labels = Labels()
+        XCTAssertNil(labels.provenance[SleapIOInfo.provenanceVersionKey])
+        let stamped = labels.stampSleapIOVersion()
+        XCTAssertEqual(stamped, SleapIOInfo.version)
+        XCTAssertEqual(labels.provenance[SleapIOInfo.provenanceVersionKey], SleapIOInfo.version)
+    }
+
+    func testStampOverwritesPreviousValue() {
+        let labels = Labels()
+        labels.provenance[SleapIOInfo.provenanceVersionKey] = "0.0.1"
+        labels.stampSleapIOVersion()
+        XCTAssertEqual(labels.provenance[SleapIOInfo.provenanceVersionKey], SleapIOInfo.version)
+    }
+}


### PR DESCRIPTION
Implements **E4.2** (#28) under epic **E4** (#26).

- `SleapIOInfo.version` (`0.3.0`), `supportedSLPFormatVersions` (`1.0...1.5`),
  `provenanceVersionKey`
- `Labels.stampSleapIOVersion()` — wired into the `.slp` save path so saves record
  `provenance["sleap_io_swift_version"]` (mirrors Python stamping `sleap_io_version`)

**Tests:** `SleapIOInfoTests` (4 cases) green; `swift build` clean.

Note: provenance is still `[String:String]` here (version is a string, so no loss).
The broader `dict[str,Any]` fix is **E8.1** (#49).

Closes #28.