### PR TITLE
feat(labels): annotation query families (E1.6, #12)

### DIFF
--- a/Sources/SleapIO/Model/LabelsAnnotationQueries.swift
+++ b/Sources/SleapIO/Model/LabelsAnnotationQueries.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Annotation query families on ``Labels``.
+///
+/// Mirrors the upstream sleap-io accessors
+/// `Labels.get_rois` / `get_masks` / `get_bboxes` / `get_centroids` / `get_label_images`.
+///
+/// `rois` and `masks` are already modeled (``Labels/rois`` / ``Labels/masks``) and are
+/// returned directly. Bounding boxes, centroids, and label images are not yet modeled
+/// (tracked under epic E7); their accessors return empty arrays today and will be
+/// populated when E7 lands. The placeholder return types are kept deliberately simple and
+/// honest rather than introducing speculative model types.
+extension Labels {
+
+    /// All labels-level regions of interest.
+    ///
+    /// - Returns: The contents of ``Labels/rois``.
+    public func getRois() -> [ROI] {
+        rois
+    }
+
+    /// All labels-level segmentation masks.
+    ///
+    /// - Returns: The contents of ``Labels/masks``.
+    public func getMasks() -> [SegmentationMask] {
+        masks
+    }
+
+    /// Bounding boxes for the dataset.
+    ///
+    /// Not yet modeled — bounding boxes arrive with epic E7. Until then this always
+    /// returns an empty array. Each entry, once populated, is expected to be a flat
+    /// `[Float]` of coordinates (e.g. `[x0, y0, x1, y1]`).
+    ///
+    /// - Returns: An empty array (placeholder pending E7).
+    public func getBboxes() -> [[Float]] {
+        []
+    }
+
+    /// Centroids for the dataset.
+    ///
+    /// Not yet modeled — centroids arrive with epic E7. Until then this always returns an
+    /// empty array. Each entry, once populated, is expected to be a `[Float]` of the form
+    /// `[x, y]`.
+    ///
+    /// - Returns: An empty array (placeholder pending E7).
+    public func getCentroids() -> [[Float]] {
+        []
+    }
+
+    /// Label images for the dataset.
+    ///
+    /// Not yet modeled — label images arrive with epic E7. Until then this always returns
+    /// an empty array.
+    ///
+    /// - Returns: An empty array (placeholder pending E7).
+    public func getLabelImages() -> [Int] {
+        []
+    }
+}

--- a/Tests/SleapIOTests/LabelsAnnotationQueriesTests.swift
+++ b/Tests/SleapIOTests/LabelsAnnotationQueriesTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+import simd
+@testable import SleapIO
+
+/// E1.6: Labels annotation query families (getRois/getMasks/getBboxes/getCentroids/getLabelImages).
+final class LabelsAnnotationQueriesTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeROI(_ name: String) -> ROI {
+        ROI(
+            annotationType: .boundingBox,
+            name: name,
+            points: [SIMD2<Float>(0, 0), SIMD2<Float>(10, 10)]
+        )
+    }
+
+    private func makeMask(_ name: String) -> SegmentationMask {
+        SegmentationMask(rleCounts: [2, 2], height: 2, width: 2, name: name)
+    }
+
+    // MARK: - getRois
+
+    func testGetRoisReturnsLabelsRois() {
+        let labels = Labels()
+        let r0 = makeROI("roi0")
+        let r1 = makeROI("roi1")
+        labels.rois = [r0, r1]
+
+        let result = labels.getRois()
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result, labels.rois)
+        XCTAssertEqual(result.map { $0.name }, ["roi0", "roi1"])
+    }
+
+    func testGetRoisEmptyWhenNoneSet() {
+        let labels = Labels()
+        XCTAssertTrue(labels.getRois().isEmpty)
+    }
+
+    // MARK: - getMasks
+
+    func testGetMasksReturnsLabelsMasks() {
+        let labels = Labels()
+        let m0 = makeMask("mask0")
+        let m1 = makeMask("mask1")
+        labels.masks = [m0, m1]
+
+        let result = labels.getMasks()
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result, labels.masks)
+        XCTAssertEqual(result.map { $0.name }, ["mask0", "mask1"])
+    }
+
+    func testGetMasksEmptyWhenNoneSet() {
+        let labels = Labels()
+        XCTAssertTrue(labels.getMasks().isEmpty)
+    }
+
+    // MARK: - Not-yet-modeled families (E7 placeholders)
+
+    func testGetBboxesReturnsEmpty() {
+        let labels = Labels()
+        XCTAssertTrue(labels.getBboxes().isEmpty)
+
+        // Still empty even when rois/masks are populated.
+        labels.rois = [makeROI("roi0")]
+        labels.masks = [makeMask("mask0")]
+        XCTAssertTrue(labels.getBboxes().isEmpty)
+    }
+
+    func testGetCentroidsReturnsEmpty() {
+        let labels = Labels()
+        XCTAssertTrue(labels.getCentroids().isEmpty)
+
+        labels.rois = [makeROI("roi0")]
+        labels.masks = [makeMask("mask0")]
+        XCTAssertTrue(labels.getCentroids().isEmpty)
+    }
+
+    func testGetLabelImagesReturnsEmpty() {
+        let labels = Labels()
+        XCTAssertTrue(labels.getLabelImages().isEmpty)
+
+        labels.rois = [makeROI("roi0")]
+        labels.masks = [makeMask("mask0")]
+        XCTAssertTrue(labels.getLabelImages().isEmpty)
+    }
+
+    // MARK: - Empty Labels behavior across all families
+
+    func testAllQueriesOnEmptyLabels() {
+        let labels = Labels()
+        XCTAssertTrue(labels.getRois().isEmpty)
+        XCTAssertTrue(labels.getMasks().isEmpty)
+        XCTAssertTrue(labels.getBboxes().isEmpty)
+        XCTAssertTrue(labels.getCentroids().isEmpty)
+        XCTAssertTrue(labels.getLabelImages().isEmpty)
+    }
+
+    // MARK: - Return-type sanity for placeholders
+
+    func testPlaceholderReturnTypes() {
+        let labels = Labels()
+        let bboxes: [[Float]] = labels.getBboxes()
+        let centroids: [[Float]] = labels.getCentroids()
+        let labelImages: [Int] = labels.getLabelImages()
+        XCTAssertEqual(bboxes.count, 0)
+        XCTAssertEqual(centroids.count, 0)
+        XCTAssertEqual(labelImages.count, 0)
+    }
+}


### PR DESCRIPTION
Implements E1.6 (#12) under epic #6. Adds an extension on `Labels` exposing the upstream annotation accessors: `getRois()`/`getMasks()` return the labels-level `rois`/`masks`, while `getBboxes()`/`getCentroids()`/`getLabelImages()` return empty arrays as honest placeholders until the corresponding model types land in epic E7 (documented in-source). Tests: LabelsAnnotationQueriesTests. New files only. Closes #12.