### PR TITLE
feat(labels): subscripts + find() with foreign-video resolution (E1.2, #8)

### DIFF
--- a/Sources/SleapIO/Model/LabelsSubscripts.swift
+++ b/Sources/SleapIO/Model/LabelsSubscripts.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Foreign-video resolution and `find()` query helpers.
+///
+/// These mirror the upstream sleap-io `Labels.__getitem__` / `find` / `match_video`
+/// semantics: a `Video` originating from a different object graph (same filename,
+/// different identity) is resolved against the local identity table before the
+/// frame store is queried. None of these methods mutate the store.
+extension Labels {
+
+    /// Resolves a possibly-foreign `Video` to the equivalent video in this
+    /// `Labels`' identity table.
+    ///
+    /// Resolution order:
+    /// 1. The video that is `===` to `video` (same object identity).
+    /// 2. Otherwise, the first video whose ``Video/filename`` matches.
+    /// 3. Otherwise, `nil`.
+    ///
+    /// - Parameter video: A video object, which may belong to a different graph.
+    /// - Returns: The matching video from ``Labels/videos``, or `nil` if none matches.
+    public func resolveVideo(_ video: Video) -> Video? {
+        // Fast path: exact identity match.
+        if videos.contains(where: { $0 === video }) {
+            return video
+        }
+        // Fallback: match by effective filename.
+        return videos.first { $0.filename == video.filename }
+    }
+
+    /// All labeled frames for a video, resolving a foreign `Video` by filename
+    /// when it is not the same object as one held by this `Labels`.
+    ///
+    /// Frames are returned sorted by ``LabeledFrame/frameIndex``.
+    ///
+    /// - Parameter video: The video to match (may be a foreign object).
+    /// - Returns: The matching frames, or an empty array if the video cannot be resolved.
+    public func frames(forVideoMatching video: Video) -> [LabeledFrame] {
+        guard let resolved = resolveVideo(video) else { return [] }
+        return frames(for: resolved)
+    }
+
+    /// Finds labeled frames for a video, with optional frame-index filtering and
+    /// on-demand creation of an empty frame.
+    ///
+    /// The supplied `video` is resolved against the local identity table first
+    /// (see ``resolveVideo(_:)``), so foreign objects with matching filenames are
+    /// handled transparently.
+    ///
+    /// - Parameters:
+    ///   - video: The video to match (may be a foreign object).
+    ///   - frameIdx: When `nil`, returns every frame for the resolved video,
+    ///     sorted by frame index. When non-`nil`, returns only the frame(s) at
+    ///     that index.
+    ///   - returnNew: When `true` and `frameIdx` is non-`nil` and no matching
+    ///     frame exists, a fresh empty ``LabeledFrame`` is created on the
+    ///     resolved video and returned. The frame is **not** added to the store.
+    /// - Returns: The matching (or newly created) frames. Empty if the video
+    ///   cannot be resolved.
+    public func find(video: Video,
+                     frameIdx: Int? = nil,
+                     returnNew: Bool = false) -> [LabeledFrame] {
+        guard let resolved = resolveVideo(video) else { return [] }
+
+        guard let frameIdx = frameIdx else {
+            // All frames for the resolved video, sorted by frame index.
+            return frames(for: resolved)
+        }
+
+        if let existing = frame(for: resolved, at: frameIdx) {
+            return [existing]
+        }
+
+        if returnNew {
+            // Create a detached empty frame; do NOT mutate the store.
+            return [LabeledFrame(video: resolved, frameIndex: frameIdx)]
+        }
+
+        return []
+    }
+}

--- a/Tests/SleapIOTests/LabelsSubscriptsTests.swift
+++ b/Tests/SleapIOTests/LabelsSubscriptsTests.swift
@@ -1,0 +1,221 @@
+import XCTest
+@testable import SleapIO
+
+/// E1.2: Labels subscripts + find() with foreign-video resolution.
+///
+/// Mirrors the upstream sleap-io `Labels.__getitem__` / `find` / `match_video`
+/// behavior: a `Video` passed in from a different object graph (same filename,
+/// different identity) is resolved against the local identity table before
+/// querying frames.
+final class LabelsSubscriptsTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Builds a minimal eager Labels with two videos, out-of-order frames,
+    /// and a single skeleton.
+    private func makeTestLabels() -> (Labels, Video, Video) {
+        let videoA = Video(filename: "videoA.mp4")
+        let videoB = Video(filename: "videoB.mp4")
+
+        let skeleton = Skeleton(name: "fly", nodes: [
+            Node(name: "head"),
+            Node(name: "thorax"),
+        ])
+
+        // Frames for videoA: indices 5, 2, 8 (intentionally out of order).
+        let frameA5 = LabeledFrame(video: videoA, frameIndex: 5, instances: [
+            Instance(skeleton: skeleton),
+        ])
+        let frameA2 = LabeledFrame(video: videoA, frameIndex: 2, instances: [
+            Instance(skeleton: skeleton),
+        ])
+        let frameA8 = LabeledFrame(video: videoA, frameIndex: 8, instances: [
+            Instance(skeleton: skeleton),
+            Instance(skeleton: skeleton),
+        ])
+
+        // Frames for videoB: index 0.
+        let frameB0 = LabeledFrame(video: videoB, frameIndex: 0, instances: [
+            Instance(skeleton: skeleton),
+        ])
+
+        let store = EagerFrameStore(frames: [frameA5, frameA2, frameA8, frameB0])
+        let labels = Labels(
+            frameStore: store,
+            videos: [videoA, videoB],
+            skeletons: [skeleton],
+            tracks: []
+        )
+
+        return (labels, videoA, videoB)
+    }
+
+    // MARK: - resolveVideo
+
+    func testResolveVideo_sameIdentityReturnsSameObject() {
+        let (labels, videoA, _) = makeTestLabels()
+        let resolved = labels.resolveVideo(videoA)
+        XCTAssertNotNil(resolved)
+        XCTAssertTrue(resolved === videoA, "Identical object should resolve to itself")
+    }
+
+    func testResolveVideo_foreignObjectMapsToLocalByFilename() {
+        let (labels, videoA, _) = makeTestLabels()
+
+        // A foreign Video with the same filename but a distinct identity.
+        let foreignA = Video(filename: "videoA.mp4")
+        XCTAssertFalse(foreignA === videoA, "Sanity: foreign video is a distinct object")
+
+        let resolved = labels.resolveVideo(foreignA)
+        XCTAssertNotNil(resolved)
+        XCTAssertTrue(
+            resolved === videoA,
+            "Foreign video with matching filename must resolve to the local video object"
+        )
+    }
+
+    func testResolveVideo_unknownFilenameReturnsNil() {
+        let (labels, _, _) = makeTestLabels()
+        let unknown = Video(filename: "does-not-exist.mp4")
+        XCTAssertNil(labels.resolveVideo(unknown))
+    }
+
+    // MARK: - frames(forVideoMatching:)
+
+    func testFramesForVideoMatching_foreignObjectReturnsRightFramesSorted() {
+        let (labels, videoA, _) = makeTestLabels()
+
+        // Foreign object, same filename as videoA.
+        let foreignA = Video(filename: "videoA.mp4")
+
+        let frames = labels.frames(forVideoMatching: foreignA)
+        XCTAssertEqual(frames.count, 3)
+        // Sorted by frame index.
+        XCTAssertEqual(frames.map { $0.frameIndex }, [2, 5, 8])
+        // Resolved to the local video identity.
+        for frame in frames {
+            XCTAssertTrue(frame.video === videoA)
+        }
+    }
+
+    func testFramesForVideoMatching_sameObjectReturnsRightFrames() {
+        let (labels, _, videoB) = makeTestLabels()
+        let frames = labels.frames(forVideoMatching: videoB)
+        XCTAssertEqual(frames.count, 1)
+        XCTAssertEqual(frames[0].frameIndex, 0)
+        XCTAssertTrue(frames[0].video === videoB)
+    }
+
+    func testFramesForVideoMatching_unknownVideoReturnsEmpty() {
+        let (labels, _, _) = makeTestLabels()
+        let unknown = Video(filename: "unknown.mp4")
+        XCTAssertTrue(labels.frames(forVideoMatching: unknown).isEmpty)
+    }
+
+    // MARK: - find (frameIdx == nil)
+
+    func testFind_nilFrameIdxReturnsAllFramesSorted() {
+        let (labels, videoA, _) = makeTestLabels()
+
+        let frames = labels.find(video: videoA)
+        XCTAssertEqual(frames.count, 3)
+        XCTAssertEqual(frames.map { $0.frameIndex }, [2, 5, 8])
+        for frame in frames {
+            XCTAssertTrue(frame.video === videoA)
+        }
+    }
+
+    func testFind_nilFrameIdxWithForeignVideoResolves() {
+        let (labels, videoA, _) = makeTestLabels()
+        let foreignA = Video(filename: "videoA.mp4")
+
+        let frames = labels.find(video: foreignA)
+        XCTAssertEqual(frames.map { $0.frameIndex }, [2, 5, 8])
+        for frame in frames {
+            XCTAssertTrue(frame.video === videoA)
+        }
+    }
+
+    // MARK: - find (frameIdx != nil)
+
+    func testFind_specificFrameIdxReturnsMatchingFrame() {
+        let (labels, videoA, _) = makeTestLabels()
+
+        let frames = labels.find(video: videoA, frameIdx: 5)
+        XCTAssertEqual(frames.count, 1)
+        XCTAssertEqual(frames[0].frameIndex, 5)
+        XCTAssertTrue(frames[0].video === videoA)
+    }
+
+    func testFind_specificFrameIdxWithForeignVideoResolves() {
+        let (labels, videoA, _) = makeTestLabels()
+        let foreignA = Video(filename: "videoA.mp4")
+
+        let frames = labels.find(video: foreignA, frameIdx: 8)
+        XCTAssertEqual(frames.count, 1)
+        XCTAssertEqual(frames[0].frameIndex, 8)
+        XCTAssertTrue(frames[0].video === videoA)
+    }
+
+    func testFind_missingFrameIdxWithoutReturnNewReturnsEmpty() {
+        let (labels, videoA, _) = makeTestLabels()
+
+        let frames = labels.find(video: videoA, frameIdx: 999)
+        XCTAssertTrue(frames.isEmpty, "No frame and returnNew=false should return empty")
+    }
+
+    func testFind_missingFrameIdxWithReturnNewCreatesEmptyFrame() {
+        let (labels, videoA, _) = makeTestLabels()
+
+        let beforeCount = labels.frameCount
+        let frames = labels.find(video: videoA, frameIdx: 999, returnNew: true)
+
+        XCTAssertEqual(frames.count, 1)
+        let newFrame = frames[0]
+        XCTAssertEqual(newFrame.frameIndex, 999)
+        XCTAssertTrue(newFrame.video === videoA, "New frame must use the resolved local video")
+        XCTAssertTrue(newFrame.instances.isEmpty, "New frame must be empty")
+
+        // The store must NOT have been mutated.
+        XCTAssertEqual(labels.frameCount, beforeCount, "find(returnNew:) must not add to the store")
+        XCTAssertNil(
+            labels.frame(for: videoA, at: 999),
+            "The freshly-created frame must not be persisted in the store"
+        )
+    }
+
+    func testFind_returnNewWithForeignVideoUsesResolvedVideo() {
+        let (labels, videoA, _) = makeTestLabels()
+        let foreignA = Video(filename: "videoA.mp4")
+
+        let frames = labels.find(video: foreignA, frameIdx: 1234, returnNew: true)
+        XCTAssertEqual(frames.count, 1)
+        XCTAssertTrue(
+            frames[0].video === videoA,
+            "returnNew with a foreign video must build the frame on the resolved local video"
+        )
+    }
+
+    func testFind_returnNewForUnknownVideoReturnsEmpty() {
+        let (labels, _, _) = makeTestLabels()
+        let unknown = Video(filename: "unknown.mp4")
+
+        // The video cannot be resolved, so there is nothing to anchor a new frame to.
+        let frames = labels.find(video: unknown, frameIdx: 5, returnNew: true)
+        XCTAssertTrue(frames.isEmpty, "Unresolvable video should yield no frame even with returnNew")
+    }
+
+    func testFind_existingFrameWithReturnNewReturnsExistingNotNew() {
+        let (labels, videoA, _) = makeTestLabels()
+
+        let existing = labels.frame(for: videoA, at: 5)
+        XCTAssertNotNil(existing)
+
+        let frames = labels.find(video: videoA, frameIdx: 5, returnNew: true)
+        XCTAssertEqual(frames.count, 1)
+        XCTAssertTrue(
+            frames[0] === existing,
+            "When a frame already exists, returnNew must return the existing object, not a fresh one"
+        )
+    }
+}


### PR DESCRIPTION
Implements E1.2 (#8) under epic #6. Adds a `Labels` extension (`Sources/SleapIO/Model/LabelsSubscripts.swift`) that resolves a possibly-foreign `Video` against the local identity table (`===` first, then by `filename`) and exposes `resolveVideo(_:)`, `frames(forVideoMatching:)`, and `find(video:frameIdx:returnNew:)`. `find()` returns all frames for a video (sorted) when `frameIdx` is nil, the matching frame when given an index, and a fresh detached empty frame when `returnNew` is set and none exists — the store is never mutated. Tests: LabelsSubscriptsTests (15 cases, all passing). New files only. Closes #8.