### PR TITLE
feat(skeleton): add flip/require/match helpers (E3.2, #22)

### DIFF
--- a/Sources/SleapIO/Model/SkeletonMatching.swift
+++ b/Sources/SleapIO/Model/SkeletonMatching.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Flip / require / match helpers for ``Skeleton``.
+///
+/// These mirror the Python sleap-io API:
+/// `Skeleton.get_flipped_node_inds`, `require_node`, `match_nodes`,
+/// `matches`, and `node_similarities`. They are used for left/right
+/// augmentation flips and for migrating points between differently
+/// ordered skeletons.
+extension Skeleton {
+
+    /// Node indices after applying all symmetry flips.
+    ///
+    /// Starts from the identity permutation `[0, 1, ..., count-1]` and, for
+    /// each symmetry pair `(a, b)`, swaps the entries at `a`'s and `b`'s
+    /// indices. Non-symmetric nodes keep their original index.
+    ///
+    /// Example: nodes `A, B_left, B_right, C` with symmetry
+    /// `(B_left, B_right)` yields `[0, 2, 1, 3]`.
+    public func getFlippedNodeInds() -> [Int] {
+        var flipped = Array(0..<nodes.count)
+        for symmetry in symmetries {
+            guard
+                let ia = index(of: symmetry.nodeA),
+                let ib = index(of: symmetry.nodeB)
+            else { continue }
+            flipped.swapAt(ia, ib)
+        }
+        return flipped
+    }
+
+    /// Return the node with the given name, optionally adding it if absent.
+    ///
+    /// - Parameters:
+    ///   - name: The node name to look up.
+    ///   - addMissing: When `true` (default) and no node with `name` exists,
+    ///     a new node is appended via ``addNode(named:)`` and returned. When
+    ///     `false`, a missing node yields `nil`.
+    /// - Returns: The existing or newly added node, or `nil` if the node is
+    ///   absent and `addMissing` is `false`.
+    @discardableResult
+    public func requireNode(_ name: String, addMissing: Bool = true) -> Node? {
+        if let existing = node(named: name) {
+            return existing
+        }
+        guard addMissing else { return nil }
+        return addNode(named: name)
+    }
+
+    /// Map names that exist in this skeleton to index pairs.
+    ///
+    /// For each entry in `names` whose name exists in this skeleton:
+    /// - `newInds` receives this skeleton's index of that name.
+    /// - `oldInds` receives the position of that name within `names`.
+    ///
+    /// Names not present in this skeleton are skipped. This is used to
+    /// migrate per-node point data when reordering or merging skeletons.
+    ///
+    /// - Parameter names: The source ordering of node names.
+    /// - Returns: Parallel arrays of `(newInds, oldInds)`.
+    public func matchNodes(_ names: [String]) -> (newInds: [Int], oldInds: [Int]) {
+        var newInds: [Int] = []
+        var oldInds: [Int] = []
+        for (oldIndex, name) in names.enumerated() {
+            guard let node = node(named: name), let newIndex = index(of: node) else { continue }
+            newInds.append(newIndex)
+            oldInds.append(oldIndex)
+        }
+        return (newInds, oldInds)
+    }
+
+    /// Whether two skeletons share the same set of node names.
+    ///
+    /// - Parameters:
+    ///   - other: The skeleton to compare against.
+    ///   - requireSameOrder: When `true`, the node names must also appear in
+    ///     the same order. Defaults to `false` (set equality only).
+    /// - Returns: `true` if the skeletons match under the given constraint.
+    public func matches(_ other: Skeleton, requireSameOrder: Bool = false) -> Bool {
+        let selfNames = nodes.map { $0.name }
+        let otherNames = other.nodes.map { $0.name }
+        if requireSameOrder {
+            return selfNames == otherNames
+        }
+        return Set(selfNames) == Set(otherNames)
+    }
+
+    /// Jaccard similarity of the two skeletons' node-name sets.
+    ///
+    /// Computed as `|intersection| / |union|`: `1.0` for identical name
+    /// sets, `0.0` for disjoint sets. An empty union (both skeletons have no
+    /// nodes) is defined as `0.0` to avoid division by zero.
+    ///
+    /// - Parameter other: The skeleton to compare against.
+    /// - Returns: A similarity score in `[0, 1]`.
+    public func nodeSimilarity(_ other: Skeleton) -> Double {
+        let selfNames = Set(nodes.map { $0.name })
+        let otherNames = Set(other.nodes.map { $0.name })
+        let unionCount = selfNames.union(otherNames).count
+        guard unionCount > 0 else { return 0.0 }
+        let intersectionCount = selfNames.intersection(otherNames).count
+        return Double(intersectionCount) / Double(unionCount)
+    }
+}

--- a/Tests/SleapIOTests/SkeletonMatchingTests.swift
+++ b/Tests/SleapIOTests/SkeletonMatchingTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+@testable import SleapIO
+
+/// E3.2: Tests for Skeleton flip/require/match helpers.
+///
+/// Upstream reference: Skeleton.get_flipped_node_inds / require_node /
+/// match_nodes / matches / node_similarities.
+final class SkeletonMatchingTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Build a skeleton from node names, optionally adding symmetry pairs.
+    private func makeSkeleton(
+        name: String = "skel",
+        nodeNames: [String],
+        symmetries: [(String, String)] = []
+    ) -> Skeleton {
+        let nodes = nodeNames.map { Node(name: $0) }
+        let lookup = Dictionary(uniqueKeysWithValues: zip(nodeNames, nodes))
+        let syms = symmetries.map { Symmetry(lookup[$0.0]!, lookup[$0.1]!) }
+        return Skeleton(name: name, nodes: nodes, symmetries: syms)
+    }
+
+    // MARK: - getFlippedNodeInds
+
+    func testGetFlippedNodeIndsSwapsSymmetricPair() {
+        // Nodes A, B_left, B_right, C with symmetry (B_left, B_right).
+        let skel = makeSkeleton(
+            nodeNames: ["A", "B_left", "B_right", "C"],
+            symmetries: [("B_left", "B_right")]
+        )
+        XCTAssertEqual(skel.getFlippedNodeInds(), [0, 2, 1, 3])
+    }
+
+    func testGetFlippedNodeIndsIdentityWhenNoSymmetries() {
+        let skel = makeSkeleton(nodeNames: ["A", "B", "C", "D"])
+        XCTAssertEqual(skel.getFlippedNodeInds(), [0, 1, 2, 3])
+    }
+
+    func testGetFlippedNodeIndsMultiplePairs() {
+        // L1,R1,L2,R2,center with symmetries (L1,R1) and (L2,R2).
+        let skel = makeSkeleton(
+            nodeNames: ["L1", "R1", "L2", "R2", "center"],
+            symmetries: [("L1", "R1"), ("L2", "R2")]
+        )
+        XCTAssertEqual(skel.getFlippedNodeInds(), [1, 0, 3, 2, 4])
+    }
+
+    func testGetFlippedNodeIndsEmptySkeleton() {
+        let skel = makeSkeleton(nodeNames: [])
+        XCTAssertEqual(skel.getFlippedNodeInds(), [])
+    }
+
+    // MARK: - requireNode
+
+    func testRequireNodeReturnsExisting() {
+        let skel = makeSkeleton(nodeNames: ["head", "tail"])
+        let head = skel.node(named: "head")
+        let required = skel.requireNode("head")
+        XCTAssertNotNil(required)
+        XCTAssertTrue(required === head, "Should return the existing node identity")
+        XCTAssertEqual(skel.nodes.count, 2, "Should not add a duplicate node")
+    }
+
+    func testRequireNodeAddsWhenMissingByDefault() {
+        let skel = makeSkeleton(nodeNames: ["head"])
+        let added = skel.requireNode("neck")
+        XCTAssertNotNil(added)
+        XCTAssertEqual(added?.name, "neck")
+        XCTAssertEqual(skel.nodes.count, 2)
+        XCTAssertTrue(skel.node(named: "neck") === added, "Added node should be retrievable by name")
+    }
+
+    func testRequireNodeReturnsNilWhenMissingAndNotAdding() {
+        let skel = makeSkeleton(nodeNames: ["head"])
+        let result = skel.requireNode("neck", addMissing: false)
+        XCTAssertNil(result)
+        XCTAssertEqual(skel.nodes.count, 1, "Should not add the node when addMissing is false")
+        XCTAssertNil(skel.node(named: "neck"))
+    }
+
+    func testRequireNodeReturnsExistingEvenWhenAddMissingFalse() {
+        let skel = makeSkeleton(nodeNames: ["head"])
+        let head = skel.node(named: "head")
+        let result = skel.requireNode("head", addMissing: false)
+        XCTAssertTrue(result === head)
+        XCTAssertEqual(skel.nodes.count, 1)
+    }
+
+    // MARK: - matchNodes
+
+    func testMatchNodesMapsOverlappingNames() {
+        // Skeleton order: A, B, C, D.
+        let skel = makeSkeleton(nodeNames: ["A", "B", "C", "D"])
+        // Incoming order: C, A, Z (Z does not exist).
+        let result = skel.matchNodes(["C", "A", "Z"])
+        // C -> this index 2, old position 0; A -> this index 0, old position 1.
+        XCTAssertEqual(result.newInds, [2, 0])
+        XCTAssertEqual(result.oldInds, [0, 1])
+    }
+
+    func testMatchNodesIdenticalOrdering() {
+        let skel = makeSkeleton(nodeNames: ["A", "B", "C"])
+        let result = skel.matchNodes(["A", "B", "C"])
+        XCTAssertEqual(result.newInds, [0, 1, 2])
+        XCTAssertEqual(result.oldInds, [0, 1, 2])
+    }
+
+    func testMatchNodesNoOverlap() {
+        let skel = makeSkeleton(nodeNames: ["A", "B"])
+        let result = skel.matchNodes(["X", "Y"])
+        XCTAssertEqual(result.newInds, [])
+        XCTAssertEqual(result.oldInds, [])
+    }
+
+    // MARK: - matches
+
+    func testMatchesSameNameSetDifferentOrder() {
+        let a = makeSkeleton(nodeNames: ["A", "B", "C"])
+        let b = makeSkeleton(nodeNames: ["C", "B", "A"])
+        XCTAssertTrue(a.matches(b), "Same name set should match when order not required")
+        XCTAssertFalse(
+            a.matches(b, requireSameOrder: true),
+            "Different order should not match when same order required"
+        )
+    }
+
+    func testMatchesSameNameSetSameOrder() {
+        let a = makeSkeleton(nodeNames: ["A", "B", "C"])
+        let b = makeSkeleton(nodeNames: ["A", "B", "C"])
+        XCTAssertTrue(a.matches(b))
+        XCTAssertTrue(a.matches(b, requireSameOrder: true))
+    }
+
+    func testMatchesDifferentNameSet() {
+        let a = makeSkeleton(nodeNames: ["A", "B", "C"])
+        let b = makeSkeleton(nodeNames: ["A", "B"])
+        XCTAssertFalse(a.matches(b))
+        XCTAssertFalse(a.matches(b, requireSameOrder: true))
+    }
+
+    // MARK: - nodeSimilarity
+
+    func testNodeSimilarityIdenticalIsOne() {
+        let a = makeSkeleton(nodeNames: ["A", "B", "C"])
+        let b = makeSkeleton(nodeNames: ["C", "B", "A"])
+        XCTAssertEqual(a.nodeSimilarity(b), 1.0, accuracy: 1e-9)
+    }
+
+    func testNodeSimilarityDisjointIsZero() {
+        let a = makeSkeleton(nodeNames: ["A", "B"])
+        let b = makeSkeleton(nodeNames: ["X", "Y"])
+        XCTAssertEqual(a.nodeSimilarity(b), 0.0, accuracy: 1e-9)
+    }
+
+    func testNodeSimilarityPartialOverlapIsJaccard() {
+        // a = {A, B, C}, b = {B, C, D}
+        // intersection = {B, C} (2), union = {A, B, C, D} (4) => 0.5
+        let a = makeSkeleton(nodeNames: ["A", "B", "C"])
+        let b = makeSkeleton(nodeNames: ["B", "C", "D"])
+        XCTAssertEqual(a.nodeSimilarity(b), 0.5, accuracy: 1e-9)
+    }
+
+    func testNodeSimilarityBothEmptyIsZero() {
+        let a = makeSkeleton(nodeNames: [])
+        let b = makeSkeleton(nodeNames: [])
+        // Empty union => define similarity as 0 (avoid divide-by-zero).
+        XCTAssertEqual(a.nodeSimilarity(b), 0.0, accuracy: 1e-9)
+    }
+}


### PR DESCRIPTION
Implements E3.2 (#22) under epic #20. Adds an extension on `Skeleton` with node flip/require/match utilities that mirror the Python sleap-io API: `getFlippedNodeInds()` (index permutation after applying symmetry swaps), `requireNode(_:addMissing:)` (fetch-or-add a node by name), `matchNodes(_:)` (map overlapping names to `(newInds, oldInds)` pairs for point migration), `matches(_:requireSameOrder:)` (compare node-name sets, optionally requiring identical order), and `nodeSimilarity(_:)` (Jaccard similarity of node-name sets). All helpers reuse existing public model APIs (`node(named:)`, `index(of:)`, `addNode(named:)`). Tests: SkeletonMatchingTests (18 cases, all passing). New files only. Closes #22.