### PR TITLE
feat(model): add LabeledFrame cleanup + classification helpers (E2.5, #18)

### DIFF
--- a/Sources/SleapIO/Model/LabeledFrameAccessors.swift
+++ b/Sources/SleapIO/Model/LabeledFrameAccessors.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+// MARK: - Instance emptiness
+
+extension Instance {
+    /// Whether this instance has no visible points.
+    ///
+    /// Mirrors the upstream `Instance.is_empty` concept used by
+    /// `LabeledFrame.remove_empty_instances`: an instance is considered empty
+    /// when none of its points are marked visible.
+    public var isEmpty: Bool {
+        !points.visibility.contains(true)
+    }
+}
+
+// MARK: - LabeledFrame cleanup + classification helpers
+
+extension LabeledFrame {
+    /// Remove instances that have no visible points.
+    ///
+    /// Upstream reference: `LabeledFrame.remove_empty_instances`.
+    public func removeEmptyInstances() {
+        instances.removeAll { $0.isEmpty }
+    }
+
+    /// Remove all predicted instances, keeping user-labeled instances.
+    ///
+    /// Upstream reference: `LabeledFrame.remove_predictions`.
+    public func removePredictions() {
+        instances.removeAll { $0 is PredictedInstance }
+    }
+
+    /// Predicted instances that are not referenced by any user instance's
+    /// `fromPredicted` link.
+    ///
+    /// Upstream reference: `LabeledFrame.unused_predictions`.
+    public var unusedPredictions: [PredictedInstance] {
+        let usedIdentities = Set(
+            userInstances.compactMap { $0.fromPredicted.map(ObjectIdentifier.init) }
+        )
+        return predictedInstances.filter {
+            !usedIdentities.contains(ObjectIdentifier($0))
+        }
+    }
+
+    /// Whether this frame has at least one user-labeled (non-predicted) instance.
+    ///
+    /// Upstream reference: `LabeledFrame.is_user_labeled`. Exposed under the
+    /// Python name; equivalent to ``hasUserInstances``.
+    public var isUserLabeled: Bool {
+        hasUserInstances
+    }
+}

--- a/Tests/SleapIOTests/LabeledFrameAccessorsTests.swift
+++ b/Tests/SleapIOTests/LabeledFrameAccessorsTests.swift
@@ -1,0 +1,204 @@
+import XCTest
+@testable import SleapIO
+
+/// E2.5: LabeledFrame cleanup + classification helpers.
+///
+/// Upstream reference: `LabeledFrame.remove_empty_instances`,
+/// `remove_predictions`, `unused_predictions`, `is_user_labeled`.
+final class LabeledFrameAccessorsTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// A 2-node skeleton used across the tests.
+    private func makeSkeleton() -> Skeleton {
+        Skeleton(name: "s", nodes: [Node(name: "a"), Node(name: "b")])
+    }
+
+    private func makeVideo() -> Video {
+        Video(filename: "v.mp4")
+    }
+
+    /// A user instance whose points all match `visible`.
+    private func makeUserInstance(skeleton: Skeleton, visible: Bool) -> Instance {
+        let inst = Instance(skeleton: skeleton)
+        for i in 0..<inst.points.count {
+            inst.points[i] = Point(x: Float(i), y: Float(i), visible: visible)
+        }
+        return inst
+    }
+
+    /// A predicted instance whose points all match `visible`.
+    private func makePredictedInstance(skeleton: Skeleton, visible: Bool) -> PredictedInstance {
+        var pts = PredictedPointsArray(count: skeleton.nodes.count)
+        for i in 0..<pts.count {
+            pts[i] = PredictedPoint(
+                point: Point(x: Float(i), y: Float(i), visible: visible),
+                score: 0.9
+            )
+        }
+        return PredictedInstance(skeleton: skeleton, points: pts, score: 0.9)
+    }
+
+    // MARK: - Instance.isEmpty
+
+    func testInstanceIsEmpty_trueWhenNoVisiblePoints() {
+        let skel = makeSkeleton()
+        XCTAssertTrue(makeUserInstance(skeleton: skel, visible: false).isEmpty)
+        XCTAssertFalse(makeUserInstance(skeleton: skel, visible: true).isEmpty)
+    }
+
+    // MARK: - removeEmptyInstances
+
+    func testRemoveEmptyInstances_dropsAllInvisibleKeepsVisible() {
+        let skel = makeSkeleton()
+        let video = makeVideo()
+
+        let visible = makeUserInstance(skeleton: skel, visible: true)
+        let invisible = makeUserInstance(skeleton: skel, visible: false)
+        let predictedVisible = makePredictedInstance(skeleton: skel, visible: true)
+        let predictedEmpty = makePredictedInstance(skeleton: skel, visible: false)
+
+        let frame = LabeledFrame(
+            video: video,
+            frameIndex: 0,
+            instances: [visible, invisible, predictedVisible, predictedEmpty]
+        )
+
+        frame.removeEmptyInstances()
+
+        XCTAssertEqual(frame.instances.count, 2)
+        XCTAssertTrue(frame.instances.contains { $0 === visible })
+        XCTAssertTrue(frame.instances.contains { $0 === predictedVisible })
+        XCTAssertFalse(frame.instances.contains { $0 === invisible })
+        XCTAssertFalse(frame.instances.contains { $0 === predictedEmpty })
+    }
+
+    func testRemoveEmptyInstances_noopWhenAllVisible() {
+        let skel = makeSkeleton()
+        let a = makeUserInstance(skeleton: skel, visible: true)
+        let b = makeUserInstance(skeleton: skel, visible: true)
+        let frame = LabeledFrame(video: makeVideo(), frameIndex: 1, instances: [a, b])
+
+        frame.removeEmptyInstances()
+
+        XCTAssertEqual(frame.instances.count, 2)
+    }
+
+    // MARK: - removePredictions
+
+    func testRemovePredictions_keepsUserInstances() {
+        let skel = makeSkeleton()
+        let user1 = makeUserInstance(skeleton: skel, visible: true)
+        let user2 = makeUserInstance(skeleton: skel, visible: false)
+        let pred1 = makePredictedInstance(skeleton: skel, visible: true)
+        let pred2 = makePredictedInstance(skeleton: skel, visible: true)
+
+        let frame = LabeledFrame(
+            video: makeVideo(),
+            frameIndex: 2,
+            instances: [user1, pred1, user2, pred2]
+        )
+
+        frame.removePredictions()
+
+        XCTAssertEqual(frame.instances.count, 2)
+        XCTAssertTrue(frame.instances.contains { $0 === user1 })
+        XCTAssertTrue(frame.instances.contains { $0 === user2 })
+        XCTAssertTrue(frame.predictedInstances.isEmpty)
+    }
+
+    func testRemovePredictions_removesAllWhenOnlyPredictions() {
+        let skel = makeSkeleton()
+        let frame = LabeledFrame(
+            video: makeVideo(),
+            frameIndex: 3,
+            instances: [
+                makePredictedInstance(skeleton: skel, visible: true),
+                makePredictedInstance(skeleton: skel, visible: true)
+            ]
+        )
+
+        frame.removePredictions()
+
+        XCTAssertTrue(frame.instances.isEmpty)
+    }
+
+    // MARK: - unusedPredictions
+
+    func testUnusedPredictions_excludesPredictionAUserWasCreatedFrom() {
+        let skel = makeSkeleton()
+        let usedPrediction = makePredictedInstance(skeleton: skel, visible: true)
+        let unusedPrediction = makePredictedInstance(skeleton: skel, visible: true)
+
+        // A user instance that was created from `usedPrediction`.
+        let user = Instance(skeleton: skel, fromPredicted: usedPrediction)
+
+        let frame = LabeledFrame(
+            video: makeVideo(),
+            frameIndex: 4,
+            instances: [usedPrediction, unusedPrediction, user]
+        )
+
+        let unused = frame.unusedPredictions
+
+        XCTAssertEqual(unused.count, 1)
+        XCTAssertTrue(unused.contains { $0 === unusedPrediction })
+        XCTAssertFalse(unused.contains { $0 === usedPrediction })
+    }
+
+    func testUnusedPredictions_allWhenNoUserReferences() {
+        let skel = makeSkeleton()
+        let pred1 = makePredictedInstance(skeleton: skel, visible: true)
+        let pred2 = makePredictedInstance(skeleton: skel, visible: true)
+        let frame = LabeledFrame(
+            video: makeVideo(),
+            frameIndex: 5,
+            instances: [pred1, pred2]
+        )
+
+        XCTAssertEqual(frame.unusedPredictions.count, 2)
+    }
+
+    func testUnusedPredictions_emptyWhenNoPredictions() {
+        let skel = makeSkeleton()
+        let frame = LabeledFrame(
+            video: makeVideo(),
+            frameIndex: 6,
+            instances: [makeUserInstance(skeleton: skel, visible: true)]
+        )
+
+        XCTAssertTrue(frame.unusedPredictions.isEmpty)
+    }
+
+    // MARK: - isUserLabeled
+
+    func testIsUserLabeled_trueWhenUserInstanceExists() {
+        let skel = makeSkeleton()
+        let frame = LabeledFrame(
+            video: makeVideo(),
+            frameIndex: 7,
+            instances: [
+                makePredictedInstance(skeleton: skel, visible: true),
+                makeUserInstance(skeleton: skel, visible: true)
+            ]
+        )
+
+        XCTAssertTrue(frame.isUserLabeled)
+    }
+
+    func testIsUserLabeled_falseWhenOnlyPredictions() {
+        let skel = makeSkeleton()
+        let frame = LabeledFrame(
+            video: makeVideo(),
+            frameIndex: 8,
+            instances: [makePredictedInstance(skeleton: skel, visible: true)]
+        )
+
+        XCTAssertFalse(frame.isUserLabeled)
+    }
+
+    func testIsUserLabeled_falseWhenEmpty() {
+        let frame = LabeledFrame(video: makeVideo(), frameIndex: 9)
+        XCTAssertFalse(frame.isUserLabeled)
+    }
+}


### PR DESCRIPTION
Implements E2.5 (#18) under epic #13. Adds a new-file-only `extension LabeledFrame` with the upstream sleap-io frame helpers: `removeEmptyInstances()` (drop instances with no visible points), `removePredictions()` (drop all `PredictedInstance`, keep user instances), `unusedPredictions` (predicted instances not referenced by any user instance's `fromPredicted` link), and `isUserLabeled` (true iff a user/non-predicted instance exists, exposing `hasUserInstances` under the Python name). Also adds `Instance.isEmpty` (no visible points) used by `removeEmptyInstances`, defined in the same new file to avoid editing existing sources. Tests: LabeledFrameAccessorsTests. New files only. Closes #18.