### PR TITLE
feat(labels): add Labels.copy() deep snapshot (E1.3, #9)

### DIFF
--- a/Sources/SleapIO/Model/LabelsCopy.swift
+++ b/Sources/SleapIO/Model/LabelsCopy.swift
@@ -1,0 +1,277 @@
+import Foundation
+
+extension Labels {
+
+    /// Produce a deep, identity-preserving clone of this `Labels`.
+    ///
+    /// Every identity object (``Video``, ``Skeleton``, ``Node``, ``Track``,
+    /// ``LabeledFrame``, ``Instance`` / ``PredictedInstance``) is reconstructed as a
+    /// new object, and value types (``PointsArray``, ``PredictedPointsArray``,
+    /// ``ROI``, ``SegmentationMask``, ``SuggestionFrame``, provenance) are copied.
+    ///
+    /// The clone is internally consistent via object-identity dedup: a cloned
+    /// frame's `video` is the same object as the corresponding entry in the
+    /// clone's `videos` table, and a cloned instance's `skeleton` / `track`
+    /// are the same objects as the corresponding entries in the clone's
+    /// `skeletons` / `tracks` tables.
+    ///
+    /// Mirrors `Labels.copy(open_videos)` in upstream sleap-io.
+    ///
+    /// If this `Labels` is lazy, it is materialized first (mutating `self`) so
+    /// that all frames are available for cloning.
+    ///
+    /// - Note: `Instance.fromPredicted` links are remapped when the target
+    ///   predicted instance lives in the same frame as the user instance. Links
+    ///   pointing to a predicted instance that cannot be located among the cloned
+    ///   instances are left `nil`.
+    ///
+    /// - Returns: A new, fully independent `Labels`.
+    public func copy() -> Labels {
+        // Materialize lazy storage so every frame can be cloned.
+        materialize()
+
+        // MARK: Clone identity tables.
+
+        // Videos: clone each, then wire up sourceVideo references via the map.
+        var videoMap: [ObjectIdentifier: Video] = [:]
+        videoMap.reserveCapacity(videos.count)
+        var clonedVideos: [Video] = []
+        clonedVideos.reserveCapacity(videos.count)
+        for video in videos {
+            let cloned = Self.cloneVideoShell(video)
+            videoMap[ObjectIdentifier(video)] = cloned
+            clonedVideos.append(cloned)
+        }
+        // Remap sourceVideo to the cloned source where it exists in the table;
+        // otherwise clone the orphaned source standalone so the link is preserved.
+        for video in videos {
+            guard let source = video.sourceVideo else { continue }
+            let clonedSelf = videoMap[ObjectIdentifier(video)]!
+            if let mappedSource = videoMap[ObjectIdentifier(source)] {
+                clonedSelf.sourceVideo = mappedSource
+            } else {
+                clonedSelf.sourceVideo = Self.cloneVideoShell(source)
+            }
+        }
+
+        // Skeletons: clone with new nodes and remapped edges/symmetries.
+        var skeletonMap: [ObjectIdentifier: Skeleton] = [:]
+        skeletonMap.reserveCapacity(skeletons.count)
+        var clonedSkeletons: [Skeleton] = []
+        clonedSkeletons.reserveCapacity(skeletons.count)
+        for skeleton in skeletons {
+            let cloned = Self.cloneSkeleton(skeleton)
+            skeletonMap[ObjectIdentifier(skeleton)] = cloned
+            clonedSkeletons.append(cloned)
+        }
+
+        // Tracks: clone by name.
+        var trackMap: [ObjectIdentifier: Track] = [:]
+        trackMap.reserveCapacity(tracks.count)
+        var clonedTracks: [Track] = []
+        clonedTracks.reserveCapacity(tracks.count)
+        for track in tracks {
+            let cloned = Track(name: track.name)
+            trackMap[ObjectIdentifier(track)] = cloned
+            clonedTracks.append(cloned)
+        }
+
+        // Helper closures that fall back to cloning an off-table object if an
+        // instance/frame references an identity object missing from the tables.
+        func mappedVideo(_ video: Video) -> Video {
+            if let v = videoMap[ObjectIdentifier(video)] { return v }
+            let v = Self.cloneVideoShell(video)
+            videoMap[ObjectIdentifier(video)] = v
+            return v
+        }
+        func mappedSkeleton(_ skeleton: Skeleton) -> Skeleton {
+            if let s = skeletonMap[ObjectIdentifier(skeleton)] { return s }
+            let s = Self.cloneSkeleton(skeleton)
+            skeletonMap[ObjectIdentifier(skeleton)] = s
+            return s
+        }
+        func mappedTrack(_ track: Track) -> Track {
+            if let t = trackMap[ObjectIdentifier(track)] { return t }
+            let t = Track(name: track.name)
+            trackMap[ObjectIdentifier(track)] = t
+            return t
+        }
+
+        // MARK: Clone frames and instances.
+
+        // Track original-instance -> cloned-instance to remap fromPredicted links.
+        var instanceMap: [ObjectIdentifier: Instance] = [:]
+
+        var clonedFrames: [LabeledFrame] = []
+        clonedFrames.reserveCapacity(frameStore.count)
+
+        for i in 0..<frameStore.count {
+            let frame = frameStore.frame(at: i)
+            let clonedFrameVideo = mappedVideo(frame.video)
+
+            var clonedInstances: [Instance] = []
+            clonedInstances.reserveCapacity(frame.instances.count)
+            for inst in frame.instances {
+                let clonedSkeleton = mappedSkeleton(inst.skeleton)
+                let clonedTrack = inst.track.map { mappedTrack($0) }
+                let clonedInst = Self.cloneInstance(inst,
+                                                    skeleton: clonedSkeleton,
+                                                    track: clonedTrack)
+                instanceMap[ObjectIdentifier(inst)] = clonedInst
+                clonedInstances.append(clonedInst)
+            }
+
+            let clonedFrame = LabeledFrame(video: clonedFrameVideo,
+                                           frameIndex: frame.frameIndex,
+                                           instances: clonedInstances,
+                                           isNegative: frame.isNegative)
+            clonedFrames.append(clonedFrame)
+        }
+
+        // Second pass: remap fromPredicted links where the target was cloned.
+        for i in 0..<frameStore.count {
+            let frame = frameStore.frame(at: i)
+            for inst in frame.instances {
+                guard let target = inst.fromPredicted,
+                      let clonedInst = instanceMap[ObjectIdentifier(inst)],
+                      let clonedTarget = instanceMap[ObjectIdentifier(target)]
+                        as? PredictedInstance else { continue }
+                clonedInst.fromPredicted = clonedTarget
+            }
+        }
+
+        // MARK: Copy metadata (value types remapped to cloned identity objects).
+
+        let clonedSuggestions: [SuggestionFrame] = suggestions.map { s in
+            SuggestionFrame(video: mappedVideo(s.video),
+                            frameIndex: s.frameIndex,
+                            group: s.group)
+        }
+
+        // Sessions reference cameras/videos; remap their video mappings to the
+        // cloned videos while preserving camera identity (cameras are not part of
+        // the top-level identity tables, so they are shared by reference).
+        let clonedSessions: [RecordingSession] = sessions.map { session in
+            var remapped: [Camera: Video] = [:]
+            for (camera, video) in session.cameraToVideo {
+                remapped[camera] = mappedVideo(video)
+            }
+            return RecordingSession(cameraToVideo: remapped)
+        }
+
+        // ROIs and masks are value structs; copy by value.
+        let clonedROIs = rois
+        let clonedMasks = masks
+        let clonedProvenance = provenance
+
+        let store = EagerFrameStore(frames: clonedFrames)
+
+        // Re-collect the deduped identity tables (in case off-table objects were
+        // discovered while cloning frames). Preserve original table ordering and
+        // append any newly discovered objects.
+        let finalVideos = Self.collectTable(original: videos, map: videoMap)
+        let finalSkeletons = Self.collectTable(original: skeletons, map: skeletonMap)
+        let finalTracks = Self.collectTable(original: tracks, map: trackMap)
+
+        return Labels(
+            frameStore: store,
+            videos: finalVideos,
+            skeletons: finalSkeletons,
+            tracks: finalTracks,
+            suggestions: clonedSuggestions,
+            sessions: clonedSessions,
+            provenance: clonedProvenance,
+            rois: clonedROIs,
+            masks: clonedMasks
+        )
+    }
+
+    // MARK: - Private clone helpers
+
+    /// Clone a video's own scalar state (not its `sourceVideo`, wired separately).
+    private static func cloneVideoShell(_ video: Video) -> Video {
+        let cloned = Video(filename: video.originalFilename,
+                           backendType: video.backendType,
+                           backendMetadata: video.backendMetadata)
+        cloned.persistedFilename = video.persistedFilename
+        cloned.frameCount = video.frameCount
+        cloned.frameSize = video.frameSize
+        return cloned
+    }
+
+    /// Clone a skeleton with brand-new `Node` objects and edges/symmetries
+    /// remapped onto those new nodes.
+    private static func cloneSkeleton(_ skeleton: Skeleton) -> Skeleton {
+        var nodeMap: [ObjectIdentifier: Node] = [:]
+        nodeMap.reserveCapacity(skeleton.nodes.count)
+        let clonedNodes: [Node] = skeleton.nodes.map { node in
+            let cloned = Node(name: node.name)
+            nodeMap[ObjectIdentifier(node)] = cloned
+            return cloned
+        }
+
+        let clonedEdges: [Edge] = skeleton.edges.compactMap { edge in
+            guard let src = nodeMap[ObjectIdentifier(edge.source)],
+                  let dst = nodeMap[ObjectIdentifier(edge.destination)] else { return nil }
+            return Edge(source: src, destination: dst)
+        }
+
+        let clonedSymmetries: [Symmetry] = skeleton.symmetries.compactMap { sym in
+            guard let a = nodeMap[ObjectIdentifier(sym.nodeA)],
+                  let b = nodeMap[ObjectIdentifier(sym.nodeB)] else { return nil }
+            return Symmetry(a, b)
+        }
+
+        return Skeleton(name: skeleton.name,
+                        nodes: clonedNodes,
+                        edges: clonedEdges,
+                        symmetries: clonedSymmetries)
+    }
+
+    /// Clone an instance (user or predicted), wiring it to the already-cloned
+    /// skeleton and track. Points are deep-copied value types; the cloned
+    /// `PointsArray.skeleton` is repointed to the cloned skeleton.
+    private static func cloneInstance(_ instance: Instance,
+                                      skeleton: Skeleton,
+                                      track: Track?) -> Instance {
+        if let predicted = instance as? PredictedInstance {
+            var ppa = predicted.predictedPoints
+            ppa.skeleton = skeleton
+            let cloned = PredictedInstance(skeleton: skeleton,
+                                           points: ppa,
+                                           score: predicted.score,
+                                           track: track,
+                                           trackingScore: predicted.trackingScore)
+            return cloned
+        } else {
+            var pts = instance.points
+            pts.skeleton = skeleton
+            let cloned = Instance(skeleton: skeleton,
+                                  points: pts,
+                                  track: track,
+                                  trackingScore: instance.trackingScore)
+            return cloned
+        }
+    }
+
+    /// Reassemble a cloned identity table preserving original order and appending
+    /// any objects discovered during frame cloning that were not in the original
+    /// table.
+    private static func collectTable<T: AnyObject>(original: [T],
+                                                   map: [ObjectIdentifier: T]) -> [T] {
+        var result: [T] = []
+        result.reserveCapacity(map.count)
+        var seen = Set<ObjectIdentifier>()
+        for obj in original {
+            if let cloned = map[ObjectIdentifier(obj)] {
+                result.append(cloned)
+                seen.insert(ObjectIdentifier(cloned))
+            }
+        }
+        for (_, cloned) in map where !seen.contains(ObjectIdentifier(cloned)) {
+            result.append(cloned)
+            seen.insert(ObjectIdentifier(cloned))
+        }
+        return result
+    }
+}

--- a/Tests/SleapIOTests/LabelsCopyTests.swift
+++ b/Tests/SleapIOTests/LabelsCopyTests.swift
@@ -1,0 +1,391 @@
+import XCTest
+@testable import SleapIO
+
+/// E1.3: `Labels.copy()` deep snapshot tests.
+///
+/// Verifies that `copy()` produces a deep, identity-preserving clone:
+/// distinct objects, independent mutation, identity dedup across the cloned
+/// graph, and preserved counts.
+final class LabelsCopyTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Build a multi-video, multi-track Labels with both user and predicted
+    /// instances, edges, symmetries, suggestions, provenance, rois, and masks.
+    private func makeTestLabels() -> Labels {
+        let videoA = Video(filename: "videoA.mp4")
+        videoA.frameCount = 100
+        videoA.frameSize = (height: 480, width: 640, channels: 3)
+        videoA.persistedFilename = "videoA_moved.mp4"
+
+        let videoB = Video(filename: "videoB.mp4",
+                           backendType: "hdf5",
+                           backendMetadata: ["dataset": "video0/video"])
+        videoB.frameCount = 50
+
+        // videoB is derived from videoA.
+        videoB.sourceVideo = videoA
+
+        let head = Node(name: "head")
+        let thorax = Node(name: "thorax")
+        let abdomen = Node(name: "abdomen")
+        let skeleton = Skeleton(name: "fly", nodes: [head, thorax, abdomen])
+        skeleton.addEdge(from: head, to: thorax)
+        skeleton.addEdge(from: thorax, to: abdomen)
+        skeleton.addSymmetry(head, abdomen)
+
+        let trackX = Track(name: "track_x")
+        let trackY = Track(name: "track_y")
+
+        // A user instance with concrete point values.
+        let userInst = Instance(skeleton: skeleton, track: trackX, trackingScore: 0.9)
+        userInst[head] = Point(x: 1, y: 2, visible: true, complete: true)
+        userInst[thorax] = Point(x: 3, y: 4, visible: true, complete: false)
+        userInst[abdomen] = Point(x: 5, y: 6, visible: false, complete: false)
+
+        // A predicted instance with scores.
+        var ppa = PredictedPointsArray(count: 3)
+        ppa.skeleton = skeleton
+        ppa[0] = PredictedPoint(x: 10, y: 11, visible: true, complete: true, score: 0.5)
+        ppa[1] = PredictedPoint(x: 12, y: 13, visible: true, complete: false, score: 0.6)
+        ppa[2] = PredictedPoint(x: 14, y: 15, visible: false, complete: false, score: 0.7)
+        let predInst = PredictedInstance(skeleton: skeleton,
+                                         points: ppa,
+                                         score: 0.85,
+                                         track: trackY,
+                                         trackingScore: 0.8)
+
+        let frameA0 = LabeledFrame(video: videoA, frameIndex: 0, instances: [userInst, predInst])
+        let frameA1 = LabeledFrame(video: videoA, frameIndex: 1, instances: [
+            Instance(skeleton: skeleton, track: trackX),
+        ])
+        let frameB0 = LabeledFrame(video: videoB, frameIndex: 0, instances: [
+            Instance(skeleton: skeleton, track: trackY),
+        ], isNegative: false)
+
+        let store = EagerFrameStore(frames: [frameA0, frameA1, frameB0])
+
+        let suggestion = SuggestionFrame(video: videoB, frameIndex: 7, group: "g1")
+        let roi = ROI(annotationType: .boundingBox, name: "roi1",
+                      points: [SIMD2(0, 0), SIMD2(10, 10)])
+        let mask = SegmentationMask(rleCounts: [2, 3, 4], height: 3, width: 3, name: "mask1")
+
+        return Labels(
+            frameStore: store,
+            videos: [videoA, videoB],
+            skeletons: [skeleton],
+            tracks: [trackX, trackY],
+            suggestions: [suggestion],
+            sessions: [],
+            provenance: ["sleap_version": "1.5.0", "source": "test"],
+            rois: [roi],
+            masks: [mask]
+        )
+    }
+
+    // MARK: - Distinct top-level object
+
+    func testCopyIsDistinctObject() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+        XCTAssertFalse(clone === original, "copy() must return a new Labels object")
+    }
+
+    // MARK: - Identity-table objects are cloned (not shared)
+
+    func testIdentityTablesAreCloned() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+
+        XCTAssertEqual(clone.videos.count, original.videos.count)
+        XCTAssertEqual(clone.skeletons.count, original.skeletons.count)
+        XCTAssertEqual(clone.tracks.count, original.tracks.count)
+
+        for (o, c) in zip(original.videos, clone.videos) {
+            XCTAssertFalse(o === c, "Each cloned video must be a new object")
+        }
+        for (o, c) in zip(original.skeletons, clone.skeletons) {
+            XCTAssertFalse(o === c, "Each cloned skeleton must be a new object")
+        }
+        for (o, c) in zip(original.tracks, clone.tracks) {
+            XCTAssertFalse(o === c, "Each cloned track must be a new object")
+        }
+    }
+
+    func testClonedSkeletonHasNewNodesAndRemappedTopology() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+
+        let oSkel = original.skeletons[0]
+        let cSkel = clone.skeletons[0]
+
+        XCTAssertEqual(cSkel.name, oSkel.name)
+        XCTAssertEqual(cSkel.nodes.map(\.name), oSkel.nodes.map(\.name))
+
+        // Nodes are new objects.
+        for (o, c) in zip(oSkel.nodes, cSkel.nodes) {
+            XCTAssertFalse(o === c, "Cloned skeleton must have new Node objects")
+        }
+
+        // Edges remapped to the cloned skeleton's own nodes.
+        XCTAssertEqual(cSkel.edges.count, oSkel.edges.count)
+        let cNodeSet = Set(cSkel.nodes.map { ObjectIdentifier($0) })
+        for edge in cSkel.edges {
+            XCTAssertTrue(cNodeSet.contains(ObjectIdentifier(edge.source)),
+                          "Edge source must reference a cloned node")
+            XCTAssertTrue(cNodeSet.contains(ObjectIdentifier(edge.destination)),
+                          "Edge destination must reference a cloned node")
+        }
+
+        // Symmetries remapped too.
+        XCTAssertEqual(cSkel.symmetries.count, oSkel.symmetries.count)
+        for sym in cSkel.symmetries {
+            XCTAssertTrue(cNodeSet.contains(ObjectIdentifier(sym.nodeA)))
+            XCTAssertTrue(cNodeSet.contains(ObjectIdentifier(sym.nodeB)))
+        }
+    }
+
+    func testClonedVideoScalarPropertiesCopied() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+
+        let oVidA = original.videos[0]
+        let cVidA = clone.videos[0]
+        XCTAssertEqual(cVidA.originalFilename, oVidA.originalFilename)
+        XCTAssertEqual(cVidA.persistedFilename, oVidA.persistedFilename)
+        XCTAssertEqual(cVidA.filename, oVidA.filename)
+        XCTAssertEqual(cVidA.frameCount, oVidA.frameCount)
+        XCTAssertEqual(cVidA.frameSize?.height, oVidA.frameSize?.height)
+        XCTAssertEqual(cVidA.frameSize?.width, oVidA.frameSize?.width)
+        XCTAssertEqual(cVidA.frameSize?.channels, oVidA.frameSize?.channels)
+
+        let oVidB = original.videos[1]
+        let cVidB = clone.videos[1]
+        XCTAssertEqual(cVidB.backendType, oVidB.backendType)
+        XCTAssertEqual(cVidB.frameCount, oVidB.frameCount)
+
+        // sourceVideo should be remapped to the cloned source video (videoA).
+        XCTAssertNotNil(cVidB.sourceVideo)
+        XCTAssertTrue(cVidB.sourceVideo === cVidA,
+                      "sourceVideo must point to the cloned source video, not the original")
+    }
+
+    // MARK: - Identity dedup across the cloned graph
+
+    func testFrameVideoIdentityDedup() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+
+        for frame in clone {
+            let matchIndex = clone.videos.firstIndex { $0 === frame.video }
+            XCTAssertNotNil(matchIndex,
+                            "Each cloned frame.video must be one of the cloned Labels' videos")
+        }
+
+        // frameA0 -> videos[0], frameB0 -> videos[1]
+        XCTAssertTrue(clone[0].video === clone.videos[0])
+        XCTAssertTrue(clone[2].video === clone.videos[1])
+    }
+
+    func testInstanceSkeletonAndTrackIdentityDedup() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+
+        for frame in clone {
+            for inst in frame.instances {
+                let skelMatch = clone.skeletons.firstIndex { $0 === inst.skeleton }
+                XCTAssertNotNil(skelMatch,
+                                "Each cloned instance.skeleton must be one of the cloned skeletons")
+                if let track = inst.track {
+                    let trackMatch = clone.tracks.firstIndex { $0 === track }
+                    XCTAssertNotNil(trackMatch,
+                                    "Each cloned instance.track must be one of the cloned tracks")
+                }
+            }
+        }
+
+        // Specifically: instance.skeleton === clone.skeletons[0]
+        XCTAssertTrue(clone[0].instances[0].skeleton === clone.skeletons[0])
+        // First user instance track is trackX === clone.tracks[0]
+        XCTAssertTrue(clone[0].instances[0].track === clone.tracks[0])
+        // Predicted instance track is trackY === clone.tracks[1]
+        XCTAssertTrue(clone[0].instances[1].track === clone.tracks[1])
+    }
+
+    // MARK: - Counts preserved
+
+    func testCountsMatchOriginal() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+
+        XCTAssertEqual(clone.frameCount, original.frameCount)
+        XCTAssertEqual(clone.instanceCount, original.instanceCount)
+        XCTAssertEqual(clone.predictedInstanceCount, original.predictedInstanceCount)
+
+        // Per-frame instance counts match.
+        for i in 0..<original.frameCount {
+            XCTAssertEqual(clone[i].instances.count, original[i].instances.count)
+            XCTAssertEqual(clone[i].frameIndex, original[i].frameIndex)
+        }
+    }
+
+    func testMetadataCopied() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+
+        XCTAssertEqual(clone.provenance, original.provenance)
+        XCTAssertEqual(clone.suggestions.count, original.suggestions.count)
+        XCTAssertEqual(clone.rois.count, original.rois.count)
+        XCTAssertEqual(clone.masks.count, original.masks.count)
+
+        // Suggestion video remapped to cloned video.
+        if let s = clone.suggestions.first {
+            XCTAssertEqual(s.frameIndex, 7)
+            XCTAssertEqual(s.group, "g1")
+            XCTAssertTrue(clone.videos.contains { $0 === s.video },
+                          "Suggestion video must be remapped to a cloned video")
+        }
+    }
+
+    // MARK: - Point/instance values cloned
+
+    func testPointValuesCopied() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+
+        let oInst = original[0].instances[0]
+        let cInst = clone[0].instances[0]
+        XCTAssertEqual(cInst.points.count, oInst.points.count)
+        for i in 0..<oInst.points.count {
+            XCTAssertEqual(cInst.points[i].x, oInst.points[i].x)
+            XCTAssertEqual(cInst.points[i].y, oInst.points[i].y)
+            XCTAssertEqual(cInst.points[i].visible, oInst.points[i].visible)
+            XCTAssertEqual(cInst.points[i].complete, oInst.points[i].complete)
+        }
+        XCTAssertEqual(cInst.trackingScore, oInst.trackingScore)
+
+        // Predicted instance scores/values.
+        guard let oPred = original[0].instances[1] as? PredictedInstance,
+              let cPred = clone[0].instances[1] as? PredictedInstance else {
+            return XCTFail("Expected a predicted instance at frame 0, index 1")
+        }
+        XCTAssertEqual(cPred.score, oPred.score)
+        XCTAssertEqual(cPred.predictedPoints.scores, oPred.predictedPoints.scores)
+        for i in 0..<oPred.predictedPoints.count {
+            XCTAssertEqual(cPred.predictedPoints[i].score, oPred.predictedPoints[i].score)
+            XCTAssertEqual(cPred.predictedPoints[i].x, oPred.predictedPoints[i].x)
+        }
+    }
+
+    // MARK: - Independence: mutating the copy must not affect the original
+
+    func testMutatingCopiedPointDoesNotAffectOriginal() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+
+        let originalX = original[0].instances[0].points[0].x
+
+        // Mutate a point in the clone.
+        clone[0].instances[0].points[0] = Point(x: 999, y: 888, visible: false, complete: false)
+
+        XCTAssertEqual(clone[0].instances[0].points[0].x, 999)
+        XCTAssertEqual(original[0].instances[0].points[0].x, originalX,
+                       "Mutating a cloned point must not affect the original")
+        XCTAssertNotEqual(original[0].instances[0].points[0].x, 999)
+    }
+
+    func testMutatingClonedInstanceTrackDoesNotAffectOriginal() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+
+        let originalTrack = original[0].instances[0].track
+
+        // Reassign the clone's instance track to nil.
+        clone[0].instances[0].track = nil
+
+        XCTAssertNil(clone[0].instances[0].track)
+        XCTAssertTrue(original[0].instances[0].track === originalTrack,
+                      "Mutating a cloned instance's track must not affect the original")
+    }
+
+    func testAddingInstanceToClonedFrameDoesNotAffectOriginal() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+
+        let originalCount = original[1].instances.count
+        clone[1].instances.append(Instance(skeleton: clone.skeletons[0]))
+
+        XCTAssertEqual(clone[1].instances.count, originalCount + 1)
+        XCTAssertEqual(original[1].instances.count, originalCount,
+                       "Adding an instance to a cloned frame must not affect the original")
+    }
+
+    func testMutatingClonedVideoDoesNotAffectOriginal() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+
+        let originalName = original.videos[0].persistedFilename
+        clone.videos[0].persistedFilename = "changed.mp4"
+
+        XCTAssertEqual(clone.videos[0].persistedFilename, "changed.mp4")
+        XCTAssertEqual(original.videos[0].persistedFilename, originalName,
+                       "Mutating a cloned video must not affect the original")
+    }
+
+    func testMutatingClonedSkeletonDoesNotAffectOriginal() {
+        let original = makeTestLabels()
+        let clone = original.copy()
+
+        let originalEdgeCount = original.skeletons[0].edges.count
+        clone.skeletons[0].addNode(named: "extra")
+
+        XCTAssertEqual(original.skeletons[0].nodes.count, 3,
+                       "Mutating a cloned skeleton must not affect the original")
+        XCTAssertEqual(original.skeletons[0].edges.count, originalEdgeCount)
+    }
+
+    // MARK: - Lazy materialization path
+
+    func testCopyMaterializesLazyLabels() {
+        // A minimal lazy store that materializes frames on demand.
+        let video = Video(filename: "lazy.mp4")
+        let skeleton = Skeleton(name: "fly", nodes: [Node(name: "a"), Node(name: "b")])
+        let frame = LabeledFrame(video: video, frameIndex: 3, instances: [
+            Instance(skeleton: skeleton),
+        ])
+        let store = TestLazyFrameStore(frames: [frame])
+        let labels = Labels(
+            frameStore: store,
+            videos: [video],
+            skeletons: [skeleton],
+            tracks: []
+        )
+        XCTAssertTrue(labels.isLazy)
+
+        let clone = labels.copy()
+        XCTAssertFalse(clone.isLazy, "copy() must materialize before cloning")
+        XCTAssertEqual(clone.frameCount, 1)
+        XCTAssertEqual(clone[0].frameIndex, 3)
+        XCTAssertTrue(clone[0].video === clone.videos[0])
+        XCTAssertTrue(clone[0].instances[0].skeleton === clone.skeletons[0])
+    }
+}
+
+/// A minimal in-test lazy `FrameStore` used to exercise `copy()`'s
+/// materialize-first behavior without depending on SleapHDF5.
+private final class TestLazyFrameStore: FrameStore, @unchecked Sendable {
+    private let frames: [LabeledFrame]
+
+    init(frames: [LabeledFrame]) {
+        self.frames = frames
+    }
+
+    var count: Int { frames.count }
+    func frame(at index: Int) -> LabeledFrame { frames[index] }
+    var isLazy: Bool { true }
+    func allFrames() -> [LabeledFrame] { frames }
+    var totalInstanceCount: Int { frames.reduce(0) { $0 + $1.instances.count } }
+    var totalPredictedInstanceCount: Int {
+        frames.reduce(0) { $0 + $1.predictedInstances.count }
+    }
+}


### PR DESCRIPTION
Implements E1.3 (#9) under epic #6. Adds `Labels.copy()`, a deep, identity-preserving clone that materializes lazy storage first, then reconstructs every identity object (Video with sourceVideo remap, Skeleton with new Nodes and remapped Edges/Symmetries, Track, LabeledFrame, Instance/PredictedInstance with fresh PointsArray/PredictedPointsArray value copies) using object-identity maps so the cloned graph is internally deduped (frame.video === clone.videos[i], instance.skeleton === clone.skeletons[j], instance.track === clone.tracks[k]). Suggestions, sessions, provenance, rois, and masks are value-copied with video references remapped; fromPredicted links are remapped when the target was cloned. Tests: LabelsCopyTests (15 cases covering distinct object, identity-table cloning, topology remap, dedup, counts, deep-mutation independence, and the lazy materialize path). New files only. Closes #9.