### PR TITLE
feat(core): Instance/PredictedInstance empty() and from(numpy:) factories (E2.3, #16)

### DIFF
--- a/Sources/SleapIO/Model/InstanceFactories.swift
+++ b/Sources/SleapIO/Model/InstanceFactories.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+// E2.3: Convenience factories for building Instance / PredictedInstance from
+// scratch or from numpy-style `(nNodes, 2)` / `(nNodes, 3)` arrays. Mirrors
+// Python `Instance.empty` / `Instance.from_numpy` and
+// `PredictedInstance.empty(score=)` / `PredictedInstance.from_numpy`.
+//
+// These round-trip with the `numpy(...)` accessors: a row whose `x` or `y` is
+// non-finite (e.g. `NaN`) becomes an invisible point, which `numpy(invisibleAsNaN:)`
+// re-emits as `[NaN, NaN]`.
+
+extension Instance {
+
+    /// An instance with one invisible point per skeleton node.
+    ///
+    /// All coordinates are `NaN` and every point is marked not-visible, so
+    /// ``isEmpty`` is `true` and ``nVisible`` is `0`. Mirrors `Instance.empty`.
+    public static func empty(skeleton: Skeleton, track: Track? = nil) -> Instance {
+        var pts = PointsArray(count: skeleton.nodes.count)
+        pts.skeleton = skeleton
+        return Instance(skeleton: skeleton, points: pts, track: track)
+    }
+
+    /// Build an instance from an `(nNodes, 2)` array of `[x, y]` rows.
+    ///
+    /// A row whose `x` or `y` is non-finite (e.g. `[NaN, NaN]`) yields an invisible
+    /// point; a finite row yields a visible point at `(x, y)`. The number of rows
+    /// should match `skeleton.nodes.count`. Mirrors `Instance.from_numpy`.
+    public static func from(numpy points: [[Float]],
+                            skeleton: Skeleton,
+                            track: Track? = nil) -> Instance {
+        var pts = PointsArray(count: skeleton.nodes.count)
+        pts.skeleton = skeleton
+        applyXY(points, to: &pts)
+        return Instance(skeleton: skeleton, points: pts, track: track)
+    }
+}
+
+extension PredictedInstance {
+
+    /// A predicted instance with one invisible, zero-score point per skeleton node.
+    ///
+    /// Mirrors `PredictedInstance.empty(score=)`.
+    public static func empty(skeleton: Skeleton,
+                             score: Float = 0,
+                             track: Track? = nil) -> PredictedInstance {
+        var pts = PredictedPointsArray(count: skeleton.nodes.count)
+        pts.skeleton = skeleton
+        return PredictedInstance(skeleton: skeleton, points: pts, score: score, track: track)
+    }
+
+    /// Build a predicted instance from an `(nNodes, 2)` or `(nNodes, 3)` array.
+    ///
+    /// Each row is `[x, y]` or `[x, y, pointScore]`. A row whose `x` or `y` is
+    /// non-finite yields an invisible point. Per-point scores come from `pointScores`
+    /// when provided, otherwise from a third column when present, otherwise `0`.
+    /// Mirrors `PredictedInstance.from_numpy`.
+    public static func from(numpy points: [[Float]],
+                            skeleton: Skeleton,
+                            score: Float = 0,
+                            pointScores: [Float]? = nil,
+                            track: Track? = nil) -> PredictedInstance {
+        var xy = PointsArray(count: skeleton.nodes.count)
+        applyXY(points, to: &xy)
+
+        var scores = ContiguousArray<Float>(repeating: 0, count: skeleton.nodes.count)
+        let n = Swift.min(points.count, scores.count)
+        if let pointScores {
+            for i in 0..<Swift.min(pointScores.count, scores.count) {
+                scores[i] = pointScores[i]
+            }
+        } else {
+            for i in 0..<n where points[i].count >= 3 {
+                scores[i] = points[i][2]
+            }
+        }
+
+        var pts = PredictedPointsArray(pointsArray: xy, scores: scores)
+        pts.skeleton = skeleton
+        return PredictedInstance(skeleton: skeleton, points: pts, score: score, track: track)
+    }
+}
+
+private extension Instance {
+
+    /// Fill `xy` from `(nNodes, 2+)` rows: finite `(x, y)` => visible point,
+    /// non-finite row => invisible point.
+    static func applyXY(_ points: [[Float]], to xy: inout PointsArray) {
+        let n = Swift.min(points.count, xy.count)
+        for i in 0..<n {
+            let row = points[i]
+            guard row.count >= 2 else { continue }
+            let x = row[0], y = row[1]
+            if x.isFinite && y.isFinite {
+                xy[i] = Point(x: x, y: y, visible: true, complete: false)
+            } else {
+                xy[i] = Point(x: x, y: y, visible: false, complete: false)
+            }
+        }
+    }
+}

--- a/Tests/SleapIOTests/InstanceFactoriesTests.swift
+++ b/Tests/SleapIOTests/InstanceFactoriesTests.swift
@@ -1,0 +1,156 @@
+import XCTest
+import simd
+@testable import SleapIO
+
+/// E2.3: Instance.empty() / from(numpy:) factories, plus the PredictedInstance
+/// variants. Mirrors Python `Instance.empty` / `Instance.from_numpy` and
+/// `PredictedInstance.empty(score=)` / `PredictedInstance.from_numpy`.
+final class InstanceFactoriesTests: XCTestCase {
+
+    private func skel3() -> (Skeleton, [Node]) {
+        let nodes = ["a", "b", "c"].map { Node(name: $0) }
+        return (Skeleton(name: "s", nodes: nodes), nodes)
+    }
+
+    // MARK: - Instance.empty
+
+    func testEmptyInstanceHasNodeCountAllInvisible() {
+        let (skel, _) = skel3()
+        let inst = Instance.empty(skeleton: skel)
+        XCTAssertEqual(inst.points.count, skel.nodes.count)
+        XCTAssertTrue(inst.isEmpty, "empty() should produce an all-invisible instance")
+        XCTAssertEqual(inst.nVisible, 0)
+        for v in inst.points.visibility {
+            XCTAssertFalse(v)
+        }
+        // numpy() of an empty instance is all-NaN rows.
+        for row in inst.numpy() {
+            XCTAssertTrue(row[0].isNaN && row[1].isNaN)
+        }
+    }
+
+    func testEmptyInstanceAttachesSkeletonAndTrack() {
+        let (skel, _) = skel3()
+        let track = Track(name: "t0")
+        let inst = Instance.empty(skeleton: skel, track: track)
+        XCTAssertTrue(inst.skeleton === skel)
+        XCTAssertTrue(inst.track === track)
+        // Skeleton attached for node-based subscript access.
+        XCTAssertTrue(inst.points.skeleton === skel)
+    }
+
+    // MARK: - Instance.from(numpy:)
+
+    func testFromNumpyRoundTrips() {
+        let (skel, _) = skel3()
+        let coords: [[Float]] = [[0, 0], [10, 20], [.nan, .nan]]
+        let inst = Instance.from(numpy: coords, skeleton: skel)
+
+        XCTAssertEqual(inst.points.count, 3)
+        XCTAssertTrue(inst.points.visibility[0])
+        XCTAssertTrue(inst.points.visibility[1])
+        XCTAssertFalse(inst.points.visibility[2], "NaN row should be invisible")
+
+        // Round-trip through numpy(): finite rows preserved, NaN row stays NaN.
+        let arr = inst.numpy()
+        XCTAssertEqual(arr.count, 3)
+        XCTAssertEqual(arr[0], [0, 0])
+        XCTAssertEqual(arr[1], [10, 20])
+        XCTAssertTrue(arr[2][0].isNaN && arr[2][1].isNaN)
+    }
+
+    func testFromNumpyStoresFiniteCoordinates() {
+        let (skel, _) = skel3()
+        let coords: [[Float]] = [[1.5, 2.5], [.nan, .nan], [7, 8]]
+        let inst = Instance.from(numpy: coords, skeleton: skel)
+        XCTAssertEqual(inst.points.coordinates[0], 1.5)
+        XCTAssertEqual(inst.points.coordinates[1], 2.5)
+        XCTAssertEqual(inst.points.coordinates[4], 7)
+        XCTAssertEqual(inst.points.coordinates[5], 8)
+    }
+
+    func testFromNumpyCarriesTrack() {
+        let (skel, _) = skel3()
+        let track = Track(name: "t1")
+        let coords: [[Float]] = [[0, 0], [1, 1], [2, 2]]
+        let inst = Instance.from(numpy: coords, skeleton: skel, track: track)
+        XCTAssertTrue(inst.track === track)
+    }
+
+    // MARK: - PredictedInstance.empty
+
+    func testPredictedEmptyHasScoreAndAllInvisible() {
+        let (skel, _) = skel3()
+        let pred = PredictedInstance.empty(skeleton: skel, score: 0.42)
+        XCTAssertEqual(pred.points.count, skel.nodes.count)
+        XCTAssertTrue(pred.isEmpty)
+        XCTAssertEqual(pred.score, 0.42, accuracy: 1e-6)
+        for s in pred.predictedPoints.scores {
+            XCTAssertEqual(s, 0, accuracy: 1e-6)
+        }
+    }
+
+    func testPredictedEmptyDefaultScoreZero() {
+        let (skel, _) = skel3()
+        let pred: PredictedInstance = .empty(skeleton: skel)
+        XCTAssertEqual(pred.score, 0, accuracy: 1e-6)
+    }
+
+    // MARK: - PredictedInstance.from(numpy:)
+
+    func testPredictedFromNumpyTwoColumns() {
+        let (skel, _) = skel3()
+        let coords: [[Float]] = [[1, 2], [3, 4], [.nan, .nan]]
+        let pred = PredictedInstance.from(numpy: coords, skeleton: skel, score: 0.9)
+
+        XCTAssertEqual(pred.score, 0.9, accuracy: 1e-6)
+        XCTAssertTrue(pred.points.visibility[0])
+        XCTAssertFalse(pred.points.visibility[2])
+
+        // Round-trips with numpy(scores: false).
+        let arr = pred.numpy(scores: false)
+        XCTAssertEqual(arr[0], [1, 2])
+        XCTAssertEqual(arr[1], [3, 4])
+        XCTAssertTrue(arr[2][0].isNaN && arr[2][1].isNaN)
+    }
+
+    func testPredictedFromNumpyThreeColumnsCarriesPerPointScores() {
+        let (skel, _) = skel3()
+        // col 2 is the per-point score.
+        let coords: [[Float]] = [[1, 2, 0.9], [3, 4, 0.8], [.nan, .nan, 0.1]]
+        let pred = PredictedInstance.from(numpy: coords, skeleton: skel, score: 0.95)
+
+        XCTAssertEqual(pred.predictedPoints.scores[0], 0.9, accuracy: 1e-6)
+        XCTAssertEqual(pred.predictedPoints.scores[1], 0.8, accuracy: 1e-6)
+        XCTAssertEqual(pred.predictedPoints.scores[2], 0.1, accuracy: 1e-6)
+
+        // Round-trips with numpy(scores: true): xy + per-point score column.
+        let arr = pred.numpy(scores: true)
+        XCTAssertEqual(arr[0], [1, 2, 0.9])
+        XCTAssertEqual(arr[1], [3, 4, 0.8])
+        XCTAssertTrue(arr[2][0].isNaN && arr[2][1].isNaN)
+        XCTAssertEqual(arr[2][2], 0.1, accuracy: 1e-6)
+    }
+
+    func testPredictedFromNumpyExplicitPointScoresOverrideColumn() {
+        let (skel, _) = skel3()
+        let coords: [[Float]] = [[1, 2], [3, 4], [5, 6]]
+        let pred = PredictedInstance.from(
+            numpy: coords, skeleton: skel, score: 0.5,
+            pointScores: [0.11, 0.22, 0.33]
+        )
+        XCTAssertEqual(pred.predictedPoints.scores[0], 0.11, accuracy: 1e-6)
+        XCTAssertEqual(pred.predictedPoints.scores[1], 0.22, accuracy: 1e-6)
+        XCTAssertEqual(pred.predictedPoints.scores[2], 0.33, accuracy: 1e-6)
+    }
+
+    func testPredictedFromNumpyCarriesTrack() {
+        let (skel, _) = skel3()
+        let track = Track(name: "t2")
+        let coords: [[Float]] = [[0, 0], [1, 1], [2, 2]]
+        let pred: PredictedInstance = .from(numpy: coords, skeleton: skel, track: track)
+        XCTAssertTrue(pred.track === track)
+        XCTAssertTrue(pred.skeleton === skel)
+        XCTAssertEqual(pred.predictedPoints.count, 3)
+    }
+}


### PR DESCRIPTION
Implements E2.3 (#16) under epic #13. Adds static factories on `Instance` and `PredictedInstance`: `empty(...)` produces an all-invisible instance with one point per skeleton node (zero-score for the predicted variant), and `from(numpy:...)` builds an instance from an `(nNodes, 2)` array (or `(nNodes, 3)` with a per-point score column for the predicted variant), treating non-finite (NaN) rows as invisible points and finite rows as visible points. These round-trip with the existing `Instance.numpy(invisibleAsNaN:)` and `PredictedInstance.numpy(scores:)` accessors. Tests: InstanceFactoriesTests. New files only. Closes #16.