### PR TITLE
feat(model): add ErrorMode and recoverable error taxonomy (E4.3, #29)

### DIFF
--- a/Sources/SleapIO/Model/ErrorMode.swift
+++ b/Sources/SleapIO/Model/ErrorMode.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Controls how recoverable errors are handled during operations such as
+/// loading, merging, or resolving missing resources.
+///
+/// - `strict`: throw on the first recoverable error.
+/// - `warn`: collect the error and continue.
+/// - `ignore`: silently drop the error and continue.
+public enum ErrorMode: Sendable {
+    case strict
+    case warn
+    case ignore
+}
+
+/// Recoverable errors that can be surfaced (and optionally collected) instead
+/// of aborting an operation outright.
+///
+/// These are distinct from ``SleapIOError`` so that callers can opt into a
+/// non-fatal, accumulating error-handling strategy via ``ErrorMode``.
+public enum RecoverableSleapError: Error, Sendable, Equatable {
+    /// A referenced video file could not be located.
+    case missingVideo(filename: String)
+    /// A skeleton's node names did not match what was expected.
+    case skeletonMismatch(expected: [String], found: [String])
+    /// A conflict was encountered while merging.
+    case mergeConflict(description: String)
+}
+
+/// Accumulator for recoverable errors used in `warn` mode.
+///
+/// Pass each recoverable error through ``handle(_:mode:)`` along with the
+/// active ``ErrorMode``. In `strict` mode the error is thrown immediately; in
+/// `warn` mode it is appended to ``errors``; in `ignore` mode it is dropped.
+public struct ErrorCollector {
+    /// The recoverable errors accumulated while running in `warn` mode.
+    public private(set) var errors: [RecoverableSleapError]
+
+    /// Creates an empty collector.
+    public init() {
+        self.errors = []
+    }
+
+    /// Handles a recoverable error according to the supplied mode.
+    ///
+    /// - Parameters:
+    ///   - error: The recoverable error to process.
+    ///   - mode: The active error-handling mode.
+    /// - Throws: `error` itself when `mode` is `.strict`.
+    public mutating func handle(_ error: RecoverableSleapError, mode: ErrorMode) throws {
+        switch mode {
+        case .strict:
+            throw error
+        case .warn:
+            errors.append(error)
+        case .ignore:
+            break
+        }
+    }
+}

--- a/Tests/SleapIOTests/ErrorModeTests.swift
+++ b/Tests/SleapIOTests/ErrorModeTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import SleapIO
+
+/// E4.3: ErrorMode + recoverable error taxonomy tests.
+final class ErrorModeTests: XCTestCase {
+
+    // MARK: - ErrorMode
+
+    func testErrorModeHasThreeCases() {
+        let modes: [ErrorMode] = [.strict, .warn, .ignore]
+        XCTAssertEqual(modes.count, 3, "ErrorMode should expose strict, warn, and ignore")
+    }
+
+    func testErrorModeIsSwitchable() {
+        // Sanity-check that all three cases are distinct and switchable.
+        func describe(_ mode: ErrorMode) -> String {
+            switch mode {
+            case .strict: return "strict"
+            case .warn: return "warn"
+            case .ignore: return "ignore"
+            }
+        }
+        XCTAssertEqual(describe(.strict), "strict")
+        XCTAssertEqual(describe(.warn), "warn")
+        XCTAssertEqual(describe(.ignore), "ignore")
+    }
+
+    // MARK: - RecoverableSleapError payloads + Equatable
+
+    func testMissingVideoCarriesFilename() {
+        let error = RecoverableSleapError.missingVideo(filename: "clip.mp4")
+        guard case let .missingVideo(filename) = error else {
+            return XCTFail("Expected missingVideo case")
+        }
+        XCTAssertEqual(filename, "clip.mp4")
+    }
+
+    func testSkeletonMismatchCarriesExpectedAndFound() {
+        let error = RecoverableSleapError.skeletonMismatch(
+            expected: ["head", "thorax"],
+            found: ["head", "abdomen"]
+        )
+        guard case let .skeletonMismatch(expected, found) = error else {
+            return XCTFail("Expected skeletonMismatch case")
+        }
+        XCTAssertEqual(expected, ["head", "thorax"])
+        XCTAssertEqual(found, ["head", "abdomen"])
+    }
+
+    func testMergeConflictCarriesDescription() {
+        let error = RecoverableSleapError.mergeConflict(description: "duplicate frame")
+        guard case let .mergeConflict(description) = error else {
+            return XCTFail("Expected mergeConflict case")
+        }
+        XCTAssertEqual(description, "duplicate frame")
+    }
+
+    func testRecoverableSleapErrorEquatable() {
+        XCTAssertEqual(
+            RecoverableSleapError.missingVideo(filename: "a.mp4"),
+            RecoverableSleapError.missingVideo(filename: "a.mp4")
+        )
+        XCTAssertNotEqual(
+            RecoverableSleapError.missingVideo(filename: "a.mp4"),
+            RecoverableSleapError.missingVideo(filename: "b.mp4")
+        )
+
+        XCTAssertEqual(
+            RecoverableSleapError.skeletonMismatch(expected: ["a"], found: ["b"]),
+            RecoverableSleapError.skeletonMismatch(expected: ["a"], found: ["b"])
+        )
+        XCTAssertNotEqual(
+            RecoverableSleapError.skeletonMismatch(expected: ["a"], found: ["b"]),
+            RecoverableSleapError.skeletonMismatch(expected: ["a"], found: ["c"])
+        )
+
+        XCTAssertEqual(
+            RecoverableSleapError.mergeConflict(description: "x"),
+            RecoverableSleapError.mergeConflict(description: "x")
+        )
+
+        // Different cases are not equal.
+        XCTAssertNotEqual(
+            RecoverableSleapError.missingVideo(filename: "a.mp4"),
+            RecoverableSleapError.mergeConflict(description: "a.mp4")
+        )
+    }
+
+    // MARK: - ErrorCollector
+
+    func testErrorCollectorStartsEmpty() {
+        let collector = ErrorCollector()
+        XCTAssertTrue(collector.errors.isEmpty)
+    }
+
+    func testErrorCollectorThrowsInStrictMode() {
+        var collector = ErrorCollector()
+        let error = RecoverableSleapError.missingVideo(filename: "missing.mp4")
+        XCTAssertThrowsError(try collector.handle(error, mode: .strict)) { thrown in
+            XCTAssertEqual(thrown as? RecoverableSleapError, error)
+        }
+        // Strict mode does not accumulate.
+        XCTAssertTrue(collector.errors.isEmpty)
+    }
+
+    func testErrorCollectorAccumulatesInWarnMode() throws {
+        var collector = ErrorCollector()
+        let first = RecoverableSleapError.missingVideo(filename: "a.mp4")
+        let second = RecoverableSleapError.mergeConflict(description: "dup")
+
+        try collector.handle(first, mode: .warn)
+        try collector.handle(second, mode: .warn)
+
+        XCTAssertEqual(collector.errors, [first, second])
+    }
+
+    func testErrorCollectorDropsInIgnoreMode() throws {
+        var collector = ErrorCollector()
+        try collector.handle(.missingVideo(filename: "a.mp4"), mode: .ignore)
+        try collector.handle(.mergeConflict(description: "dup"), mode: .ignore)
+        XCTAssertTrue(collector.errors.isEmpty, "Ignore mode should drop errors silently")
+    }
+
+    func testErrorCollectorMixedModes() throws {
+        var collector = ErrorCollector()
+        // warn accumulates, ignore drops, then a strict throws.
+        try collector.handle(.missingVideo(filename: "warn.mp4"), mode: .warn)
+        try collector.handle(.missingVideo(filename: "ignored.mp4"), mode: .ignore)
+
+        XCTAssertEqual(collector.errors, [.missingVideo(filename: "warn.mp4")])
+
+        XCTAssertThrowsError(
+            try collector.handle(.mergeConflict(description: "boom"), mode: .strict)
+        )
+        // The strict failure is not appended.
+        XCTAssertEqual(collector.errors, [.missingVideo(filename: "warn.mp4")])
+    }
+}


### PR DESCRIPTION
Implements E4.3 (#29) under epic #26. Adds `ErrorMode` (strict/warn/ignore), `RecoverableSleapError` (missingVideo / skeletonMismatch / mergeConflict, Equatable), and an `ErrorCollector` helper that throws in strict mode, accumulates in warn mode, and drops in ignore mode. The existing `SleapIOError` enum is left untouched so exhaustive switches keep compiling. Tests: ErrorModeTests. New files only. Closes #29.